### PR TITLE
Use generic app id

### DIFF
--- a/Examples/BasicApp/BasicApp.xcodeproj/project.pbxproj
+++ b/Examples/BasicApp/BasicApp.xcodeproj/project.pbxproj
@@ -290,7 +290,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.patrickbalestra.metadata.BasicApp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.example.metadata.BasicApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -307,7 +307,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.patrickbalestra.metadata.BasicApp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.example.metadata.BasicApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
I just noticed this, we were using a personal id in the Example App