### PR TITLE
Can't install v0.0.1 from SwiftPackageManager

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -347,9 +347,9 @@
         "package": "SwiftPM",
         "repositoryURL": "https://github.com/apple/swift-package-manager.git",
         "state": {
-          "branch": "swift-4.2-branch",
+          "branch": null,
           "revision": "235aacc514cb81a6881364b0fedcb3dd083228f3",
-          "version": null
+          "version": "0.3.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/spotify/xclogparser", from: "0.2.22"),
-        .package(url: "https://github.com/apple/swift-package-manager.git", .branch("swift-4.2-branch")),
+        .package(url: "https://github.com/apple/swift-package-manager.git", .exact("0.3.0")),
         .package(url: "https://github.com/grpc/grpc-swift.git", .exact("1.0.0-alpha.9")),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.23.0"),
         .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.15.0"),


### PR DESCRIPTION
## Problem
generate Package.swift
```
// swift-tools-version:5.1
import PackageDescription

let package = Package(
    name: "Tools",
    dependencies: [
         .package(url: "https://github.com/spotify/XCMetrics", .exact("0.0.1"))
    ]
)
```

then, run `swift run -c release` causes error below.

`error: because package xcmetrics is required using a version-based requirement and it depends on unversion package swift-package-manager and root depends on XCMetrics 0.0.1, version solving failed.`

## Error reason
`swift-package-manager` uses `branch` as dependency. `branch` is treated as unversion.

## How to fixed
use `0.3.0`

0.3.0 is same revision as swift-4.2-branch

- [swift-4.2-branch](https://github.com/apple/swift-package-manager/tree/swift-4.2-branch) rev. 235aacc
- [0.3.0](https://github.com/apple/swift-package-manager/tree/0.3.0) rev. 235aacc