### PR TITLE
Edit doc with reference to official Docker image

### DIFF
--- a/DeploymentExamples/MultiInstances/xcmetrics-deployment.yaml
+++ b/DeploymentExamples/MultiInstances/xcmetrics-deployment.yaml
@@ -48,7 +48,7 @@ spec:
 
 
       - name: xcmetrics-server
-        image: "Replace with your XCMetrics image (e.g. gcr.io/my_gcp_project/xcmetrics)"
+        image: spotify/xcmetrics:latest
         env:
         - name: XCMETRICS_START_JOBS_SAME_INSTANCE
           value: "0" # Jobs will be run in other process

--- a/DeploymentExamples/MultiInstances/xcmetrics-jobs-deployment.yaml
+++ b/DeploymentExamples/MultiInstances/xcmetrics-jobs-deployment.yaml
@@ -49,7 +49,7 @@ spec:
 
 
       - name: xcmetrics-jobs
-        image: "Replace with your XCMetrics image (e.g. gcr.io/my_gcp_project/xcmetrics)"
+        image: spotify/xcmetrics:latest
         command: ["./XCMetricsBackend",
                   "queues",
                   "--env",

--- a/DeploymentExamples/SingleInstance/xcmetrics-deployment.yaml
+++ b/DeploymentExamples/SingleInstance/xcmetrics-deployment.yaml
@@ -48,7 +48,7 @@ spec:
 
 
       - name: xcmetrics-server
-        image: "Replace with your XCMetrics image (e.g. gcr.io/my_gcp_project/xcmetrics)"
+        image: spotify/xcmetrics:latest
         env:
         - name: XCMETRICS_START_JOBS_SAME_INSTANCE
           value: "1" # Jobs will run in this same instance

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ _XCMetrics is the easiest way to collect Xcode builds metrics and improve your d
 
 [![Build Status](https://github.com/spotify/XCMetrics/workflows/CI/badge.svg)](https://github.com/spotify/XCMetrics/workflows/CI/badge.svg)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
+[![Docker image](https://img.shields.io/docker/pulls/spotify/xcmetrics.svg)](https://hub.docker.com/r/spotify/xcmetrics)
 [![Slack](https://slackin.spotify.com/badge.svg)](https://slackin.spotify.com)
 
 ## Overview

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -1,0 +1,52 @@
+version: "3.8"
+
+services:
+
+  redis:
+    image: redis
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+
+  postgresql:
+    image: postgres
+    ports:
+      - "5432:5432"
+    environment:
+      # default values for development purposes only
+      - POSTGRES_USER=xcmetrics-dev
+      - POSTGRES_PASSWORD=xcmetrics-dev
+      - POSTGRES_DB=xcmetrics-dev
+      - PGDATA=/data/postgres-xcmetrics
+    volumes:
+      - postgres:/data/postgres-xcmetrics
+    healthcheck:
+      test: pg_isready -U xcmetrics-dev -d xcmetrics-dev
+      interval: 10s
+      timeout: 3s
+      retries: 3
+
+  xcmetrics:
+    image: spotify/xcmetrics:latest
+    depends_on:
+      redis:
+        condition: service_healthy
+      postgresql:
+        condition: service_healthy
+    ports:
+      - "8080:8080"
+    environment:
+      - XCMETRICS_START_JOBS_SAME_INSTANCE=1
+      - XCMETRICS_USE_ASYNC_LOG_PROCESSING=1
+      - XCMETRICS_REDACT_USER_DATA=1
+      - XCMETRICS_USE_GCS_REPOSITORY=0
+      - LOG_LEVEL=info
+      - REDIS_HOST=redis
+      - DB_HOST=postgresql
+
+volumes:
+  postgres:

--- a/docs/How to Deploy Backend.md
+++ b/docs/How to Deploy Backend.md
@@ -1,6 +1,8 @@
 # Backend Deployment
 
-This repo includes a Dockerfile that you can use to build a docker image (`docker build .`) that can be deployed to the cloud.
+We provide an [official Docker image](https://hub.docker.com/r/spotify/xcmetrics): `spotify/xcmetrics`.
+
+You can also build your own, this repo includes a Dockerfile that you can use to build a docker image (`docker build .`) that can be deployed to your own Docker registry.
 
 ## 1. Requirements
 
@@ -100,13 +102,9 @@ The easiest way to start is to click on the following "Run on Google Cloud" butt
 
 4. Add permissions to Cloud's Run Service Account for Cloud SQL. By default, Cloud Run uses the service account named `<project number>-compute@developer.gserviceaccount.com`. It will need the permissions **Cloud SQL Client**
 
-5. You can skip the next sections if you're using "Run in Google Cloud" button. Next, you need to build a Docker image and deploy it using Cloud Run:
+5. You can skip the next sections if you're using "Run in Google Cloud" button.
 
-```shell
-gcloud builds submit --tag gcr.io/<my_gcp_project>/xcmetricsserver --timeout=30m
-```
-
-6. Use the [Cloud Run console](https://console.cloud.google.com/run) to crrate a new Service using the Image you just uploaded. When you're creating it you need to add the Cloud SQL Connection in Advanced Settings as [described here](https://cloud.google.com/sql/docs/postgres/connect-run#configuring)
+6. Use the [Cloud Run console](https://console.cloud.google.com/run) to create a new Service. When you're creating it you need to add the Cloud SQL Connection in Advanced Settings as [described here](https://cloud.google.com/sql/docs/postgres/connect-run#configuring)
 
 You will need some specific Env Variables setup so the App can run in this environment:
 
@@ -192,15 +190,7 @@ You will need to install [kubectl](https://cloud.google.com/kubernetes-engine/do
 gcloud container clusters get-credentials name-of-cluster
 ```
 
-### 3. Build and upload an image with the XCMetrics Backend
-
-From the root of the project (where the Dockerfile is), run this command changing the name of the project for yours.
-
-```shell
-gcloud builds submit --tag gcr.io/my-gcp-project/xcmetrics --timeout=30m
-```
-
-### 4. Create Kubernetes Secrets
+### 3. Create Kubernetes Secrets
 
 We will store in the Kubernetes Secrets two values: the Service account's credentials JSON file you created in the Pre Requisites and the password to the database. Run these commands:
 
@@ -214,7 +204,7 @@ kubectl create secret generic db-secret \
   --from-literal=password='database password'
 ```
 
-### 5. Deploy the Kubernetes artifacts
+### 4. Deploy the Kubernetes artifacts
 
 Go to the **DeploymentExamples** folder and choose one type: either SingleInstance or MultiInstances (check the beginning of this document to know the differences) and change to that folder.
 
@@ -222,25 +212,23 @@ You will need to edit some values.
 
 In `xcmetrics-service.yaml`:
 
-1. Change the image value to the uri you used to create it in Step 3  (`gcr.io/my-gcp-project/xcmetrics`).
-2. Replace the name of your Cloud SQL connection name here:
+1. Replace the name of your Cloud SQL connection name here:
 ```yaml
         command: ["/cloud_sql_proxy",
                   "-instances=Replace with your Cloud SQL connection string=tcp:5432",
                   "-credential_file=/secrets/service_account.json"]
 ```
-3. For Multi instance deployments: Change the name of the environment variables **`XCMETRICS_GOOGLE_PROJECT`** and **`XCMETRICS_GCS_BUCKET`**.
+2. For Multi instance deployments: Change the name of the environment variables **`XCMETRICS_GOOGLE_PROJECT`** and **`XCMETRICS_GCS_BUCKET`**.
 
 For MultiInstance Deployments, in `xcmetrics-jobs-deployment.yaml`
 
-1. Change the image to the uri you used to create it in Step 3  (`gcr.io/my-gcp-project/xcmetrics`).
-2. Replace the name of your Cloud SQL connection name here:
+1. Replace the name of your Cloud SQL connection name here:
 ```yaml
         command: ["/cloud_sql_proxy",
                   "-instances=Replace with your Cloud SQL connection string=tcp:5432",
                   "-credential_file=/secrets/service_account.json"]
 ```
-3. Change the name of the environment variables **`XCMETRICS_GOOGLE_PROJECT`** and **`XCMETRICS_GCS_BUCKET`**.
+2. Change the name of the environment variables **`XCMETRICS_GOOGLE_PROJECT`** and **`XCMETRICS_GCS_BUCKET`**.
 
 Now, you're ready to deploy the XCMetrics artifacts:
 

--- a/docs/Run the Backend Locally.md
+++ b/docs/Run the Backend Locally.md
@@ -4,7 +4,27 @@ It's useful to run the backend locally to test that you can ingest data to it be
 
 The Backend is built using the [Vapor 4.0 framework](https://vapor.codes). We advise to read the [official documentation](https://docs.vapor.codes/4.0/) if you plan to contribute to it. Another good resource for learning it, is [this tutorial](https://www.raywenderlich.com/11555468-getting-started-with-server-side-swift-with-vapor-4)
 
-## 1. Docker
+## 1. Running it from our Docker Image
+
+The easiest way to run it is to use our prebuilt [Docker Image](https://hub.docker.com/r/spotify/xcmetrics). Because it requires a Redis and a Postgres instance, we provide a Docker compose file that configures them for you. The file is called `docker-compose-local.yml`.
+
+1. If you haven't, install [Docker for Mac](https://docs.docker.com/docker-for-mac/).
+2. From the command line, run this command:
+
+```
+docker-compose -f docker-compose-local.yml up
+```
+
+The command will start the Postgres database, Redis and the XCMetrics backend. 
+The XCMetrics backend should be available in the port **8080**.
+
+To check that it works you can simply run
+
+```
+curl -I http://localhost:8080/hello
+```
+
+## 2. Running it from Xcode
 
 The Backend needs Redis and Postgresql to run. This repo contains a `docker-compose.yml` file that you can use to start them. From the command line run
 `docker-compose up -d`
@@ -12,9 +32,9 @@ The Backend needs Redis and Postgresql to run. This repo contains a `docker-comp
 **Note:** Remember to stop the docker instances when you're done using the Backend locally with `docker-compose stop`
 
 
-## 2. Run the migrations
+### 2.1 Database migrations
 
-The migrations will create the table in the Database. You only need to run them the first time you're going to start the backend or if a table changed since the last time you ran it. That information can be found in the Changelog.
+The migrations will create the tables that the project uses in the Database. You only need to run them the first time you're going to start the backend or if a table changed since the last time you ran it. That information can be found in the Changelog.
 
 From the command line
 
@@ -29,7 +49,7 @@ Or from Xcode, select the **XCMetricsBackend** schema and setup `migrate` as an 
 
 **Note:** You will get a prompt to confirm the migrations. Just press `y`.
 
-## 3. Start the backend
+### 2.2 Start the backend
 
 From the command line:
 
@@ -39,7 +59,7 @@ swift run XCMetricsBackend
 
 Or from Xcode: remove the `migrate` argument and run the **XCMetricsBackend** schema
 
-## 4. Verify that is running
+### 2.3 Verify that is running
 
 The backend will start at port 8080. 
 
@@ -47,13 +67,12 @@ Run
 
 `curl -I http://localhost:8080/hello`
 
-## 5. Change the client's URL
 
-Open the file `MetricsServicePublisherHTTP.swift` and change the default url to point to localhost.
+## 3. Insert Xcode build log data using the XCMetrics Client
 
-## 6. Insert some data
+Configure a Xcode project to use `XCMetrics` as described in our [Getting Started guide](https://github.com/spotify/XCMetrics/blob/main/docs/Getting%20Started.md). Double check that in the Post-build action you pass localhost to the `--serviceURL` parameter: `--serviceURL http://localhost:8080/v1/metrics`.
 
-Run `XCMetrics` and check that the build data was inserted in the database. You can use any Postgres client like [Postico](https://eggerapps.at/postico/). The Postgres instance is running in localhost, port 5432. Check the `docker-compose.yml` file for the database name and the default user and password. The main table is called `builds`. You will see the build data in that table.
+Once you send data to the backend by building the Xcode project where you configured `XCMetrics`, verify that it was inserted by inspecting the database. You can use any Postgres client like [Postico](https://eggerapps.at/postico/). The Postgres instance is running in localhost, port 5432. Check the `docker-compose.yml` file for the database name and the default user and password. The main table is called `builds`. You will see the build data in that table.
 
 >Note: make sure to change the authentication values when deploying your service to production not to use the default values.
 
@@ -88,5 +107,4 @@ Things to verify: Redis will try to start in Port `6379` and Postgres in `5432`.
     ports:
        - "6500:6379"
 ```
-
 


### PR DESCRIPTION
Now that we have an official Docker Image, it's easier to run the backend locally using it without the need to build it yourself. 

This PR adds a new docker compose configuration to do that with one command:

`docker-compose -f docker-compose-local.yml up`

I also updated the documentation to simplify several steps by just using this image.