### PR TITLE
Add XCMetricsPlugins library and first ThermalThrottling plugin

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,6 +11,7 @@ let package = Package(
         .executable(name: "XCMetrics", targets: ["XCMetricsApp"]),
         .executable(name: "XCMetricsBackend", targets: ["XCMetricsBackend"]),
         .library(name: "XCMetricsClient", targets: ["XCMetricsClient"]),
+        .library(name: "XCMetricsPlugins", targets: ["XCMetricsPlugins"]),
     ],
     dependencies: [
         .package(url: "https://github.com/spotify/xclogparser", from: "0.2.22"),
@@ -36,6 +37,10 @@ let package = Package(
         .target(
             name: "XCMetricsClient",
             dependencies: ["XCLogParser", "XCMetricsProto", "XCMetricsUtils", .product(name: "Utility", package: "SwiftPM"), "GRPC", "NIO", "NIOHTTP2", "MobiusCore", "MobiusExtras", "CryptoSwift", "Yams",  "ArgumentParser"]
+        ),
+        .target(
+            name: "XCMetricsPlugins",
+            dependencies: ["XCMetricsClient", "XCMetricsUtils"]
         ),
         .target(
             name: "XCMetricsUtils",
@@ -73,6 +78,10 @@ let package = Package(
         .testTarget(
             name: "XCMetricsTests",
             dependencies: ["XCMetricsClient", "XCMetricsProto", .product(name: "Utility", package: "SwiftPM"), "MobiusTest"]
+        ),
+        .testTarget(
+            name: "XCMetricsPluginsTests",
+            dependencies: ["XCMetricsPlugins"]
         ),
         .testTarget(name: "XCMetricsBackendLibTests", dependencies: [
             .target(name: "XCMetricsBackendLib"),

--- a/Sources/XCMetricsPlugins/ThermalThrottlingPlugin.swift
+++ b/Sources/XCMetricsPlugins/ThermalThrottlingPlugin.swift
@@ -1,0 +1,55 @@
+// Copyright (c) 2021 Spotify AB.
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import Foundation
+import XCMetricsClient
+import XCMetricsUtils
+
+public struct ThermalThrottlingPlugin {
+
+    private let shell: ShellOutFunction
+
+    init(shell: @escaping ShellOutFunction = shellGetStdout) {
+        self.shell = shell
+    }
+
+    public func create() -> XCMetricsPlugin {
+        return XCMetricsPlugin(name: "Thermal Throttling", body: { _ -> [String : String] in
+            let captureGroup = "cpuspeed"
+            let regex = "[.\n]*CPU_Speed_Limit \t= (?<\(captureGroup)>[0-9]*)"
+
+            guard let thermStdout = try? shell("pmset", ["-g", "therm"], nil, nil) else { return [:] }
+            let nsrange = NSRange(thermStdout.startIndex..<thermStdout.endIndex, in: thermStdout)
+            let reg = try! NSRegularExpression(pattern: regex, options: [])
+            var cpuSpeedLimit: String?
+            reg.enumerateMatches(in: thermStdout, options: [], range: nsrange) { match, _, stop in
+                guard let match = match else { return }
+                let matchRange = match.range(withName: captureGroup)
+                if matchRange.location != NSNotFound, let range = Range(matchRange, in: thermStdout) {
+                    cpuSpeedLimit = String(thermStdout[range])
+                }
+            }
+            if let value = cpuSpeedLimit {
+                return ["CPU_Speed_Limit": value]
+            } else {
+                return [:]
+            }
+        })
+    }
+}

--- a/Tests/XCMetricsPluginsTests/ThermaThrottlingPluginTests.swift
+++ b/Tests/XCMetricsPluginsTests/ThermaThrottlingPluginTests.swift
@@ -1,0 +1,62 @@
+// Copyright (c) 2021 Spotify AB.
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import XCTest
+@testable import XCMetricsPlugins
+@testable import XCMetricsClient
+import XCMetricsUtils
+
+class ThermaThrottlingPluginTests: XCTestCase {
+
+    func testParseThermInfo100() {
+        let fakeShellOutFunction: ShellOutFunction = { _,_,_,_ in
+            return """
+Note: No thermal warning level has been recorded
+Note: No performance warning level has been recorded
+2021-01-25 15:04:29 +0100 CPU Power notify
+    CPU_Scheduler_Limit \t= 100
+    CPU_Available_CPUs \t= 12
+    CPU_Speed_Limit \t= 100
+"""
+        }
+        let plugin = ThermalThrottlingPlugin(shell: fakeShellOutFunction).create()
+        // This plugin doesn't need any environment variables, just pass an empty dictionary.
+        let pluginData = plugin.body([:])
+        let expectedData = ["CPU_Speed_Limit": "100"]
+        XCTAssertEqual(pluginData, expectedData)
+    }
+
+    func testParseThermInfo25() {
+        let fakeShellOutFunction: ShellOutFunction = { _,_,_,_ in
+            return """
+Note: No thermal warning level has been recorded
+Note: No performance warning level has been recorded
+2021-01-25 15:04:29 +0100 CPU Power notify
+    CPU_Scheduler_Limit \t= 100
+    CPU_Available_CPUs \t= 12
+    CPU_Speed_Limit \t= 25
+"""
+        }
+        let plugin = ThermalThrottlingPlugin(shell: fakeShellOutFunction).create()
+        // This plugin doesn't need any environment variables, just pass an empty dictionary.
+        let pluginData = plugin.body([:])
+        let expectedData = ["CPU_Speed_Limit": "25"]
+        XCTAssertEqual(pluginData, expectedData)
+    }
+}


### PR DESCRIPTION
This PR adds the first `XCMetricsPlugin` called `ThermalThrottling` that collects the current thermal throttling state of the machine.
Some fixes to our Shell wrapper are also included.