### PR TITLE
Add GitPlugin to XCMetricsPlugins

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -40,7 +40,7 @@ let package = Package(
         ),
         .target(
             name: "XCMetricsPlugins",
-            dependencies: ["XCMetricsClient", "XCMetricsUtils"]
+            dependencies: ["XCMetricsClient", "XCMetricsUtils", "CryptoSwift"]
         ),
         .target(
             name: "XCMetricsUtils",

--- a/Sources/XCMetricsPlugins/GitPlugin.swift
+++ b/Sources/XCMetricsPlugins/GitPlugin.swift
@@ -1,0 +1,65 @@
+// Copyright (c) 2021 Spotify AB.
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import Foundation
+import XCMetricsClient
+import XCMetricsUtils
+
+public struct GitPlugin {
+    
+    public enum GitData {
+        case branch // the current branch name
+        case latestSHA // the most recent commit hash in short format (6)
+    }
+
+    private let gitDirectoryPath: String
+    private let gitData: [GitData]
+    private let shell: ShellOutFunction
+
+    /// Initializes a `GitPlugin` using a configurable location for the git directory
+    /// as well as the git data to attach the associated build metadata.
+    /// - Parameter gitDirectoryPath: The location of the git directory to use - usualy Xcode's `${SRCROOT}` environment variable can be used (this variable is not available in the default environment variables for XCMetrics, and would need to be passed in).
+    /// - Parameter gitData: The data to be retrieved from git (eg: the build's current branch).  Available data points can be found and added to the `GitData` enumeration.
+    /// - Parameter shell: Will default to `shellGetStdout`
+    public init(gitDirectoryPath: String, gitData: [GitData] = [.branch, .latestSHA], shell: @escaping ShellOutFunction = shellGetStdout) {
+        self.gitDirectoryPath = gitDirectoryPath
+        self.gitData = gitData
+        self.shell = shell
+    }
+
+    public func create() -> XCMetricsPlugin {
+        return XCMetricsPlugin(name: "Git", body: { _ -> [String : String] in
+            guard !gitData.isEmpty else { return [:] }
+
+            return gitData.reduce(into: [String: String]()) {
+                dictionary, target  in
+                switch target {
+                case .branch:
+                    if let branch = try? shell("git", ["-C", gitDirectoryPath, "rev-parse", "--abbrev-ref", "HEAD"], nil, nil) {
+                        dictionary["Git_Branch"] = branch
+                    }
+                case .latestSHA:
+                    if let latestSHA = try? shell("git", ["-C", gitDirectoryPath, "rev-parse", "--short=6", "--verify", "HEAD"], nil, nil) {
+                        dictionary["Git_Commit_SHA"] = latestSHA
+                    }
+                }
+            }
+        })
+    }
+}

--- a/Tests/XCMetricsPluginsTests/GitPluginTests.swift
+++ b/Tests/XCMetricsPluginsTests/GitPluginTests.swift
@@ -29,7 +29,7 @@ class GitPluginTests: XCTestCase {
         }
         let plugin = GitPlugin(gitDirectoryPath: "", gitData: [.branch], shell: fakeShellOutFunction).create()
         let pluginData = plugin.body([:])
-        let expectedData = ["Git_Branch": "main"]
+        let expectedData = ["git_branch": "main"]
         XCTAssertEqual(pluginData, expectedData)
     }
     
@@ -39,7 +39,47 @@ class GitPluginTests: XCTestCase {
         }
         let plugin = GitPlugin(gitDirectoryPath: "", gitData: [.latestSHA], shell: fakeShellOutFunction).create()
         let pluginData = plugin.body([:])
-        let expectedData = ["Git_Commit_SHA": "123f4d"]
+        let expectedData = ["git_commit_sha": "123f4d"]
+        XCTAssertEqual(pluginData, expectedData)
+    }
+    
+    func testGitIsDirty() {
+        let fakeShellOutFunction: ShellOutFunction = { _,_,_,_ in
+            return "M Package.swift"
+        }
+        let plugin = GitPlugin(gitDirectoryPath: "", gitData: [.isDirty], shell: fakeShellOutFunction).create()
+        let pluginData = plugin.body([:])
+        let expectedData = ["git_is_dirty": "true"]
+        XCTAssertEqual(pluginData, expectedData)
+    }
+    
+    func testGitIsNotDirty() {
+        let fakeShellOutFunction: ShellOutFunction = { _,_,_,_ in
+            return ""
+        }
+        let plugin = GitPlugin(gitDirectoryPath: "", gitData: [.isDirty], shell: fakeShellOutFunction).create()
+        let pluginData = plugin.body([:])
+        let expectedData = ["git_is_dirty": "false"]
+        XCTAssertEqual(pluginData, expectedData)
+    }
+    
+    func testGitUserEmailRedacted() {
+        let fakeShellOutFunction: ShellOutFunction = { _,_,_,_ in
+            return "redacted@email.com"
+        }
+        let plugin = GitPlugin(gitDirectoryPath: "", gitData: [.userEmail(redacted: true)], shell: fakeShellOutFunction).create()
+        let pluginData = plugin.body([:])
+        let expectedData = ["git_user_email": "b94ae061e2153f07113b89df8afe121a"]
+        XCTAssertEqual(pluginData, expectedData)
+    }
+    
+    func testGitUserEmailNotRedacted() {
+        let fakeShellOutFunction: ShellOutFunction = { _,_,_,_ in
+            return "redacted@email.com"
+        }
+        let plugin = GitPlugin(gitDirectoryPath: "", gitData: [.userEmail(redacted: false)], shell: fakeShellOutFunction).create()
+        let pluginData = plugin.body([:])
+        let expectedData = ["git_user_email": "redacted@email.com"]
         XCTAssertEqual(pluginData, expectedData)
     }
 }

--- a/Tests/XCMetricsPluginsTests/GitPluginTests.swift
+++ b/Tests/XCMetricsPluginsTests/GitPluginTests.swift
@@ -1,0 +1,45 @@
+// Copyright (c) 2021 Spotify AB.
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import XCTest
+@testable import XCMetricsPlugins
+@testable import XCMetricsClient
+import XCMetricsUtils
+
+class GitPluginTests: XCTestCase {
+    func testGitBranch() {
+        let fakeShellOutFunction: ShellOutFunction = { _,_,_,_ in
+            return "main"
+        }
+        let plugin = GitPlugin(gitDirectoryPath: "", gitData: [.branch], shell: fakeShellOutFunction).create()
+        let pluginData = plugin.body([:])
+        let expectedData = ["Git_Branch": "main"]
+        XCTAssertEqual(pluginData, expectedData)
+    }
+    
+    func testGitSHA() {
+        let fakeShellOutFunction: ShellOutFunction = { _,_,_,_ in
+            return "123f4d"
+        }
+        let plugin = GitPlugin(gitDirectoryPath: "", gitData: [.latestSHA], shell: fakeShellOutFunction).create()
+        let pluginData = plugin.body([:])
+        let expectedData = ["Git_Commit_SHA": "123f4d"]
+        XCTAssertEqual(pluginData, expectedData)
+    }
+}


### PR DESCRIPTION
This PR proposes adding an `XCMetricsPlugin` to surface data from git and attach it to a build's metadata, taking an initial pass at resolving #9.  There are two things worth calling out:

- When initialized, the `GitPlugin` will require the path of the associated git directory to look for.  This is necessary because Xcode's `$SRCROOT` environment variable does not appear to be available along with some of the other environment variables used in `XCMetrics`, and because the `XCMetrics` executable will not be able to call git commands without knowing where to look.
- This PR includes only the options to retrieve the current branch and the latest commit on said branch, though it hopefully makes surfacing more data points from git (when needed) easy to do.

I went ahead and just copied in the license headers added in `ThermalThrottling` on #13, though if there is a different approach to that I'm happy to follow up.

Thanks! 🙌🏽