### PR TITLE
Add Indexes to table, optimise query and add new endpoint

### DIFF
--- a/Sources/XCMetricsBackendLib/Common/Models/Step.swift
+++ b/Sources/XCMetricsBackendLib/Common/Models/Step.swift
@@ -21,14 +21,16 @@ import Fluent
 import Vapor
 import XCLogParser
 
-final class Step: Model, Content, PartitionedByDay {
+public final class Step: Model, Content, PartitionedByDay {
 
-    typealias IDValue = String
+    public typealias IDValue = String
 
-    static let schema = "build_steps"
+    public static let schema = "build_steps"
+
+    public init() {}
 
     @ID(custom: .id, generatedBy: IDProperty.Generator.user)
-    var id: String?
+    public var id: String?
 
     @Field(key: "build_identifier")
     var buildIdentifier: String

--- a/Sources/XCMetricsBackendLib/Common/Models/Target.swift
+++ b/Sources/XCMetricsBackendLib/Common/Models/Target.swift
@@ -21,14 +21,18 @@ import Fluent
 import Vapor
 import XCLogParser
 
-final class Target: Model, Content, PartitionedByDay {
+public final class Target: Model, Content, PartitionedByDay {
 
-    typealias IDValue = String
+    public typealias IDValue = String
 
-    static let schema = "build_targets"
+    public static let schema = "build_targets"
+
+    public init() {
+        
+    }
 
     @ID(custom: .id, generatedBy: IDProperty.Generator.user)
-    var id: String?
+    public var id: String?
 
     @Field(key: "build_identifier")
     var buildIdentifier: String

--- a/Sources/XCMetricsBackendLib/Common/Repositories/Postgress/Migrations/AddBuildIdentifierIndexes.swift
+++ b/Sources/XCMetricsBackendLib/Common/Repositories/Postgress/Migrations/AddBuildIdentifierIndexes.swift
@@ -26,7 +26,7 @@ struct AddBuildIdentifierIndexToTarget: Migration {
 
     func prepare(on database: Database) -> EventLoopFuture<Void> {
         guard let sql = database as? SQLDatabase else {
-            preconditionFailure("AddBuildIdIndexToTarget can only run on a SQL database")
+            preconditionFailure("AddBuildIdentifierIndexToTarget can only run on a SQL database")
         }
         return sql.raw("""
                 CREATE INDEX "index_build_identifier_on_targets"
@@ -43,7 +43,7 @@ struct AddBuildIdentifierIndexToTarget: Migration {
 
     func revert(on database: Database) -> EventLoopFuture<Void> {
         guard let sql = database as? SQLDatabase else {
-            preconditionFailure("AddBuildIdIndexToTarget can only run on a SQL database")
+            preconditionFailure("AddBuildIdentifierIndexToTarget can only run on a SQL database")
         }
         return sql.raw("""
                 DROP INDEX "index_build_identifier_on_targets";

--- a/Sources/XCMetricsBackendLib/Common/Repositories/Postgress/Migrations/AddBuildIdentifierIndexes.swift
+++ b/Sources/XCMetricsBackendLib/Common/Repositories/Postgress/Migrations/AddBuildIdentifierIndexes.swift
@@ -1,0 +1,279 @@
+// Copyright (c) 2021 Spotify AB.
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import Foundation
+
+import Fluent
+import FluentSQL
+
+struct AddBuildIdentifierIndexToTarget: Migration {
+
+    func prepare(on database: Database) -> EventLoopFuture<Void> {
+        guard let sql = database as? SQLDatabase else {
+            preconditionFailure("AddBuildIdIndexToTarget can only run on a SQL database")
+        }
+        return sql.raw("""
+                CREATE INDEX "index_build_identifier_on_targets"
+                ON \(raw: Target.schema) using btree(build_identifier);
+                """)
+                .run()
+            .flatMap {
+                sql.raw("""
+                        DROP INDEX "index_build_identifier_on_targets";
+                        """)
+                        .run()
+            }
+    }
+
+    func revert(on database: Database) -> EventLoopFuture<Void> {
+        guard let sql = database as? SQLDatabase else {
+            preconditionFailure("AddBuildIdIndexToTarget can only run on a SQL database")
+        }
+        return sql.raw("""
+                DROP INDEX "index_build_identifier_on_targets";
+                """)
+                .run()
+    }
+
+}
+
+struct AddBuildIdentifierIndexToStep: Migration {
+
+    func prepare(on database: Database) -> EventLoopFuture<Void> {
+        guard let sql = database as? SQLDatabase else {
+            preconditionFailure("AddBuildIdentifierIndexToStep can only run on a SQL database")
+        }
+        return sql.raw("""
+                CREATE INDEX "index_build_identifier_on_steps"
+                ON \(raw: Step.schema) using btree(build_identifier);
+                """)
+                .run()
+    }
+
+    func revert(on database: Database) -> EventLoopFuture<Void> {
+        guard let sql = database as? SQLDatabase else {
+            preconditionFailure("AddBuildIdentifierIndexToStep can only run on a SQL database")
+        }
+        return sql.raw("""
+                DROP INDEX "index_build_identifier_on_steps";
+                """)
+                .run()
+    }
+
+}
+
+struct AddBuildIdentifierIndexToBuildErrors: Migration {
+
+    func prepare(on database: Database) -> EventLoopFuture<Void> {
+        guard let sql = database as? SQLDatabase else {
+            preconditionFailure("AddBuildIdentifierIndexToBuildErrors can only run on a SQL database")
+        }
+        return sql.raw("""
+                CREATE INDEX "index_build_identifier_on_build_errors"
+                ON \(raw: BuildError.schema) using btree(build_identifier);
+                """)
+                .run()
+    }
+
+    func revert(on database: Database) -> EventLoopFuture<Void> {
+        guard let sql = database as? SQLDatabase else {
+            preconditionFailure("AddBuildIdentifierIndexToBuildErrors can only run on a SQL database")
+        }
+        return sql.raw("""
+                DROP INDEX "index_build_identifier_on_build_errors";
+                """)
+                .run()
+    }
+
+}
+
+struct AddBuildIdentifierIndexToBuildWarnings: Migration {
+
+    func prepare(on database: Database) -> EventLoopFuture<Void> {
+        guard let sql = database as? SQLDatabase else {
+            preconditionFailure("AddBuildIdentifierIndexToBuildWarnings can only run on a SQL database")
+        }
+        return sql.raw("""
+                CREATE INDEX "index_build_identifier_on_build_warnings"
+                ON \(raw: BuildWarning.schema) using btree(build_identifier);
+                """)
+                .run()
+    }
+
+    func revert(on database: Database) -> EventLoopFuture<Void> {
+        guard let sql = database as? SQLDatabase else {
+            preconditionFailure("AddBuildIdentifierIndexToBuildWarnings can only run on a SQL database")
+        }
+        return sql.raw("""
+                DROP INDEX "index_build_identifier_on_build_warnings";
+                """)
+                .run()
+    }
+
+}
+
+struct AddBuildIdentifierIndexToBuildNotes: Migration {
+
+    func prepare(on database: Database) -> EventLoopFuture<Void> {
+        guard let sql = database as? SQLDatabase else {
+            preconditionFailure("AddBuildIdentifierIndexToBuildNotes can only run on a SQL database")
+        }
+        return sql.raw("""
+                CREATE INDEX "index_build_identifier_on_build_notes"
+                ON \(raw: BuildNote.schema) using btree(build_identifier);
+                """)
+                .run()
+    }
+
+    func revert(on database: Database) -> EventLoopFuture<Void> {
+        guard let sql = database as? SQLDatabase else {
+            preconditionFailure("AddBuildIdentifierIndexToBuildNotes can only run on a SQL database")
+        }
+        return sql.raw("""
+                DROP INDEX "index_build_identifier_on_build_notes";
+                """)
+                .run()
+    }
+
+}
+
+struct AddBuildIdentifierIndexToBuildHost: Migration {
+
+    func prepare(on database: Database) -> EventLoopFuture<Void> {
+        guard let sql = database as? SQLDatabase else {
+            preconditionFailure("AddBuildIdentifierIndexToBuildHost can only run on a SQL database")
+        }
+        return sql.raw("""
+                CREATE INDEX "index_build_identifier_on_build_hosts"
+                ON \(raw: BuildHost.schema) using btree(build_identifier);
+                """)
+                .run()
+    }
+
+    func revert(on database: Database) -> EventLoopFuture<Void> {
+        guard let sql = database as? SQLDatabase else {
+            preconditionFailure("AddBuildIdentifierIndexToBuildHost can only run on a SQL database")
+        }
+        return sql.raw("""
+                DROP INDEX "index_build_identifier_on_build_hosts";
+                """)
+                .run()
+    }
+
+}
+
+struct AddBuildIdentifierIndexToSwiftFunctions: Migration {
+
+    func prepare(on database: Database) -> EventLoopFuture<Void> {
+        guard let sql = database as? SQLDatabase else {
+            preconditionFailure("AddBuildIdentifierIndexToSwiftFunctions can only run on a SQL database")
+        }
+        return sql.raw("""
+                CREATE INDEX "index_build_identifier_on_swift_functions"
+                ON \(raw: SwiftFunction.schema) using btree(build_identifier);
+                """)
+                .run()
+    }
+
+    func revert(on database: Database) -> EventLoopFuture<Void> {
+        guard let sql = database as? SQLDatabase else {
+            preconditionFailure("AddBuildIdentifierIndexToSwiftFunctions can only run on a SQL database")
+        }
+        return sql.raw("""
+                DROP INDEX "index_build_identifier_on_swift_functions";
+                """)
+                .run()
+    }
+
+}
+
+struct AddBuildIdentifierIndexToSwiftTypeChecks: Migration {
+
+    func prepare(on database: Database) -> EventLoopFuture<Void> {
+        guard let sql = database as? SQLDatabase else {
+            preconditionFailure("AddBuildIdentifierIndexToSwiftTypeChecks can only run on a SQL database")
+        }
+        return sql.raw("""
+                CREATE INDEX "index_build_identifier_on_swift_type_checks"
+                ON \(raw: SwiftTypeChecks.schema) using btree(build_identifier);
+                """)
+                .run()
+    }
+
+    func revert(on database: Database) -> EventLoopFuture<Void> {
+        guard let sql = database as? SQLDatabase else {
+            preconditionFailure("AddBuildIdentifierIndexToSwiftTypeChecks can only run on a SQL database")
+        }
+        return sql.raw("""
+                DROP INDEX "index_build_identifier_on_swift_type_checks";
+                """)
+                .run()
+    }
+
+}
+
+struct AddBuildIdentifierIndexToXcodeVersion: Migration {
+
+    func prepare(on database: Database) -> EventLoopFuture<Void> {
+        guard let sql = database as? SQLDatabase else {
+            preconditionFailure("AddBuildIdentifierIndexToXcodeVersion can only run on a SQL database")
+        }
+        return sql.raw("""
+                CREATE INDEX "index_build_identifier_on_xcode_versions"
+                ON \(raw: XcodeVersion.schema) using btree(build_identifier);
+                """)
+                .run()
+    }
+
+    func revert(on database: Database) -> EventLoopFuture<Void> {
+        guard let sql = database as? SQLDatabase else {
+            preconditionFailure("AddBuildIdentifierIndexToXcodeVersion can only run on a SQL database")
+        }
+        return sql.raw("""
+                DROP INDEX "index_build_identifier_on_xcode_versions";
+                """)
+                .run()
+    }
+
+}
+
+struct AddBuildIdentifierIndexToBuildMetadata: Migration {
+
+    func prepare(on database: Database) -> EventLoopFuture<Void> {
+        guard let sql = database as? SQLDatabase else {
+            preconditionFailure("AddBuildIdentifierIndexToBuildMetadata can only run on a SQL database")
+        }
+        return sql.raw("""
+                CREATE INDEX "index_build_identifier_on_build_metadata"
+                ON \(raw: BuildMetadata.schema) using btree(build_identifier);
+                """)
+                .run()
+    }
+
+    func revert(on database: Database) -> EventLoopFuture<Void> {
+        guard let sql = database as? SQLDatabase else {
+            preconditionFailure("AddBuildIdentifierIndexToBuildMetadata can only run on a SQL database")
+        }
+        return sql.raw("""
+                DROP INDEX "index_build_identifier_on_build_metadata";
+                """)
+                .run()
+    }
+
+}

--- a/Sources/XCMetricsBackendLib/Common/Repositories/Postgress/Migrations/AddStepIdentifiersIndexes.swift
+++ b/Sources/XCMetricsBackendLib/Common/Repositories/Postgress/Migrations/AddStepIdentifiersIndexes.swift
@@ -1,0 +1,73 @@
+// Copyright (c) 2021 Spotify AB.
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import Foundation
+
+import Fluent
+import FluentSQL
+
+struct AddStepIdentifierIndexToSwiftFunctions: Migration {
+
+    func prepare(on database: Database) -> EventLoopFuture<Void> {
+        guard let sql = database as? SQLDatabase else {
+            preconditionFailure("AddStepIdentifierIndexToSwiftFunctions can only run on a SQL database")
+        }
+        return sql.raw("""
+                CREATE INDEX "index_step_identifier_on_swift_functions"
+                ON \(raw: SwiftFunction.schema) using btree(step_identifier);
+                """)
+                .run()
+    }
+
+    func revert(on database: Database) -> EventLoopFuture<Void> {
+        guard let sql = database as? SQLDatabase else {
+            preconditionFailure("AddStepIdentifierIndexToSwiftFunctions can only run on a SQL database")
+        }
+        return sql.raw("""
+                DROP INDEX "index_step_identifier_on_swift_functions";
+                """)
+                .run()
+    }
+
+}
+
+struct AddStepIdentifierIndexToSwiftTypeChecks: Migration {
+
+    func prepare(on database: Database) -> EventLoopFuture<Void> {
+        guard let sql = database as? SQLDatabase else {
+            preconditionFailure("AddStepIdentifierIndexToSwiftTypeChecks can only run on a SQL database")
+        }
+        return sql.raw("""
+                CREATE INDEX "index_step_identifier_on_swift_type_checks"
+                ON \(raw: SwiftTypeChecks.schema) using btree(step_identifier);
+                """)
+                .run()
+    }
+
+    func revert(on database: Database) -> EventLoopFuture<Void> {
+        guard let sql = database as? SQLDatabase else {
+            preconditionFailure("AddStepIdentifierIndexToSwiftTypeChecks can only run on a SQL database")
+        }
+        return sql.raw("""
+                DROP INDEX "index_step_identifier_on_swift_type_checks";
+                """)
+                .run()
+    }
+
+}

--- a/Sources/XCMetricsBackendLib/Common/Repositories/Postgress/Migrations/AddTargetIdentifierIndexes.swift
+++ b/Sources/XCMetricsBackendLib/Common/Repositories/Postgress/Migrations/AddTargetIdentifierIndexes.swift
@@ -1,0 +1,49 @@
+// Copyright (c) 2021 Spotify AB.
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import Foundation
+
+import Fluent
+import FluentSQL
+
+struct AddTargetIdentifierIndexToSteps: Migration {
+
+    func prepare(on database: Database) -> EventLoopFuture<Void> {
+        guard let sql = database as? SQLDatabase else {
+            preconditionFailure("AddTargetIdentifierIndexToSteps can only run on a SQL database")
+        }
+
+        return sql.raw("""
+                CREATE INDEX "index_target_identifier_on_steps"
+                ON \(raw: Step.schema) using btree(target_identifier);
+                """)
+                .run()
+    }
+
+    func revert(on database: Database) -> EventLoopFuture<Void> {
+        guard let sql = database as? SQLDatabase else {
+            preconditionFailure("AddTargetIdentifierIndexToSteps can only run on a SQL database")
+        }
+        return sql.raw("""
+                DROP INDEX "index_target_identifier_on_steps";
+                """)
+                .run()
+    }
+
+}

--- a/Sources/XCMetricsBackendLib/Common/Utils/Date+Utils.swift
+++ b/Sources/XCMetricsBackendLib/Common/Utils/Date+Utils.swift
@@ -1,0 +1,45 @@
+// Copyright (c) 2021 Spotify AB.
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import Foundation
+
+extension Date {
+
+    /// Returns the `Date` represented by a String in the format used by the Partitioned tables
+    /// - Parameter day: String with a day in format yyyyMMdd, example: `20201231`
+    /// - Returns: A `Date` if the `day` could be parsed, `nil` if not
+    static func xcm_fromPartitionDay(_ day: String) -> Date? {
+        let parser = xcm_getPartitionedTableFormatter()
+        return parser.date(from: day)
+    }
+
+    /// Returns the date formatted with the format
+    /// used to create the Day-sharding tables in Postgres
+    /// - Returns: A `String` with the date formatted with format yyyyMMdd
+    func xcm_toPartitionedTableFormat() -> String {
+        return Self.xcm_getPartitionedTableFormatter().string(from: self)
+    }
+
+    private static func xcm_getPartitionedTableFormatter() -> DateFormatter {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyyMMdd"
+        return formatter
+    }
+
+}

--- a/Sources/XCMetricsBackendLib/Common/Utils/File.swift
+++ b/Sources/XCMetricsBackendLib/Common/Utils/File.swift
@@ -1,0 +1,8 @@
+//
+//  File.swift
+//  
+//
+//  Created by Erick Camacho Chavarria on 2021-02-03.
+//
+
+import Foundation

--- a/Sources/XCMetricsBackendLib/Common/Utils/File.swift
+++ b/Sources/XCMetricsBackendLib/Common/Utils/File.swift
@@ -1,8 +1,0 @@
-//
-//  File.swift
-//  
-//
-//  Created by Erick Camacho Chavarria on 2021-02-03.
-//
-
-import Foundation

--- a/Sources/XCMetricsBackendLib/Common/Utils/String+Utils.swift
+++ b/Sources/XCMetricsBackendLib/Common/Utils/String+Utils.swift
@@ -22,7 +22,7 @@ import Foundation
 extension String {
 
     func xcm_toSchemaName() -> String {
-        let snakeCased = camelCaseToSnakeCase()
+        let snakeCased = xcm_camelCaseToSnakeCase()
 
         if snakeCased.last != "s" && snakeCased != "build_metadata" {
             return snakeCased + "s"
@@ -30,7 +30,7 @@ extension String {
         return snakeCased
     }
 
-    func camelCaseToSnakeCase() -> String {
+    func xcm_camelCaseToSnakeCase() -> String {
         let acronymPattern = "([A-Z]+)([A-Z][a-z]|[0-9])"
         let normalPattern = "([a-z0-9])([A-Z])"
         return self.processCamelCaseRegex(pattern: acronymPattern)?
@@ -43,4 +43,5 @@ extension String {
         let range = NSRange(location: 0, length: count)
         return regex?.stringByReplacingMatches(in: self, options: [], range: range, withTemplate: "$1_$2")
     }
+
 }

--- a/Sources/XCMetricsBackendLib/Config/configure.swift
+++ b/Sources/XCMetricsBackendLib/Config/configure.swift
@@ -77,7 +77,22 @@ public func configure(_ app: Application) throws {
                        AddDetailsToNotes(),
                        AddDetailsToWarnings(),
                        AddBuildStatusIndex(),
-                       AddProjectNameIndex())
+                       AddProjectNameIndex(),
+                       AddBuildIdentifierIndexToTarget(),
+                       AddBuildIdentifierIndexToBuildErrors(),
+                       AddBuildIdentifierIndexToStep(),
+                       AddBuildIdentifierIndexToBuildErrors(),
+                       AddBuildIdentifierIndexToBuildWarnings(),
+                       AddBuildIdentifierIndexToBuildNotes(),
+                       AddBuildIdentifierIndexToBuildHost(),
+                       AddBuildIdentifierIndexToSwiftFunctions(),
+                       AddBuildIdentifierIndexToSwiftTypeChecks(),
+                       AddBuildIdentifierIndexToXcodeVersion(),
+                       AddBuildIdentifierIndexToBuildMetadata(),
+                       AddTargetIdentifierIndexToSteps(),
+                       AddStepIdentifierIndexToSwiftFunctions(),
+                       AddStepIdentifierIndexToSwiftTypeChecks()
+                       )
 
 
     if config.useAsyncLogProcessing {


### PR DESCRIPTION
As we collect more data, we started to have some slow queries. This PR addresses this issue:

1. Creates indexes for `build_identifier`, `target_identifier` and `step_identifier`.
2. Optimises the query that fetches the list of `Target` that belong to a build by using the full table name partition.

These changes resulted in the `v1/build/info` endpoint to return data in less than a second in our internal installation, before the changes it was taking 60 secs.

Additionally, adds an endpoint to fetch the list of `Step` that belong to a `Target`, that uses the same technique of using an index plus the full table name for the query. Before doing this change it was almost impossible to make a query to our `Step` table, because it was taken like 10 mins.