### PR TITLE
Determine if the host was suspended

### DIFF
--- a/Sources/XCMetricsBackendLib/UploadMetrics/LogProcessing/MetricsProcessor.swift
+++ b/Sources/XCMetricsBackendLib/UploadMetrics/LogProcessing/MetricsProcessor.swift
@@ -16,7 +16,8 @@ struct MetricsProcessor {
             projectName: metricsRequest.extraInfo.projectName,
             userId: userId,
             userIdSHA256: userIdSHA256,
-            isCI: isCI
+            isCI: isCI,
+            sleepTime: metricsRequest.extraInfo.sleepTime
         )
     }
 

--- a/Sources/XCMetricsBackendLib/UploadMetrics/Model/UploadMetricsModel.swift
+++ b/Sources/XCMetricsBackendLib/UploadMetrics/Model/UploadMetricsModel.swift
@@ -115,6 +115,9 @@ final class ExtraInfo: Codable {
 
     /// True if the build was performed on a continuous integration machine, false otherwise.
     let isCI: Bool
+
+    /// The last time the host went to sleep as reported by sysctl's `kern.sleeptime` property.
+    let sleepTime: Int?
 }
 
 extension ByteBuffer {

--- a/Sources/XCMetricsClient/Network/MetricsRequest.swift
+++ b/Sources/XCMetricsClient/Network/MetricsRequest.swift
@@ -30,11 +30,14 @@ final class ExtraInfo: Encodable {
 
     let isCI: Bool
 
-    init(projectName: String, machineName: String, user: String, isCI: Bool) {
+    let sleepTime: Int
+
+    init(projectName: String, machineName: String, user: String, isCI: Bool, sleepTime: Int) {
         self.projectName = projectName
         self.machineName = machineName
         self.user = user
         self.isCI = isCI
+        self.sleepTime = sleepTime
     }
 }
 

--- a/Sources/XCMetricsClient/Network/MultipartRequestBuilder.swift
+++ b/Sources/XCMetricsClient/Network/MultipartRequestBuilder.swift
@@ -71,7 +71,9 @@ class MultipartRequestBuilder {
         let jsonEncoder = JSONEncoder()
         /// Backend will decide if the username will be stored hashed or not based on its configuration
         let user = MacOSUsernameReader().userID ?? "unknown"
-        let extraInfo = ExtraInfo(projectName: projectName, machineName: machineName, user: user, isCI: isCI)
+        let sleepTime = HardwareFactsFetcherImplementation().sleepTime
+        let extraInfo = ExtraInfo(projectName: projectName, machineName: machineName, user: user, isCI: isCI,
+                                  sleepTime: sleepTime)
         let extraJson = try jsonEncoder.encode(extraInfo)
         if let extraData = toJSONFormField(named: "extraInfo", jsonData: extraJson, using: boundary) {
           httpBody.append(extraData)


### PR DESCRIPTION
- Send the `sleepTime` from the host and use it to determine if it was suspended in the middle of a build.
- This new attribute is an Optional in the Backend to keep backwards compatibility with the previous version of the client that did not send it.