### PR TITLE
Report swift errors from xcodebuild

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -384,8 +384,8 @@
         "repositoryURL": "https://github.com/spotify/xclogparser",
         "state": {
           "branch": null,
-          "revision": "fc9d949b23c7790c172592d7109e770082bd55b9",
-          "version": "0.2.22"
+          "revision": "ab85951bc54bfcbae27b2b1f22097e955f8e41e5",
+          "version": "0.2.24"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
         .library(name: "XCMetricsUtils", targets: ["XCMetricsUtils"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/spotify/xclogparser", from: "0.2.22"),
+        .package(url: "https://github.com/spotify/xclogparser", from: "0.2.24"),
         .package(url: "https://github.com/apple/swift-package-manager.git", .exact("0.3.0")),
         .package(url: "https://github.com/grpc/grpc-swift.git", .exact("1.0.0-alpha.9")),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.23.0"),


### PR DESCRIPTION
Bumps XCLogParser to a version that fixes a regression that caused some Swift errors generated by `xcodebuild` not being reported as such.