### PR TITLE
Fix broken migration

### DIFF
--- a/Sources/XCMetricsBackendLib/Config/configure.swift
+++ b/Sources/XCMetricsBackendLib/Config/configure.swift
@@ -81,7 +81,6 @@ public func configure(_ app: Application) throws {
                        AddBuildIdentifierIndexToTarget(),
                        AddBuildIdentifierIndexToBuildErrors(),
                        AddBuildIdentifierIndexToStep(),
-                       AddBuildIdentifierIndexToBuildErrors(),
                        AddBuildIdentifierIndexToBuildWarnings(),
                        AddBuildIdentifierIndexToBuildNotes(),
                        AddBuildIdentifierIndexToBuildHost(),


### PR DESCRIPTION
Removes duplicated call to `AddBuildIdentifierIndexToBuildErrors`, this causes the docker image to fail to start locally