### PR TITLE
Add flag to skip inserting notes into the database

### DIFF
--- a/Examples/BasicApp/BasicApp.xcodeproj/xcshareddata/xcschemes/BasicApp.xcscheme
+++ b/Examples/BasicApp/BasicApp.xcodeproj/xcshareddata/xcschemes/BasicApp.xcscheme
@@ -11,7 +11,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Run Script"
-               scriptText = "${SRCROOT}/../../XCMetricsLauncher ${SRCROOT}/../../.build/release/XCMetrics --name BasicApp --buildDir ${BUILD_DIR} --serviceURL http://localhost:8080/v1/metrics&#10;&#10;&#10;">
+               scriptText = "${SRCROOT}/../../XCMetricsLauncher ${SRCROOT}/../../.build/release/XCMetrics --name BasicApp --buildDir ${BUILD_DIR} --isCI false --skipNotes false --serviceURL http://localhost:8080/v1/metrics&#10;&#10;&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/Package.resolved
+++ b/Package.resolved
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/krzyzanowskim/CryptoSwift.git",
         "state": {
           "branch": null,
-          "revision": "af1b58fc569bfde777462349b9f7314b61762be0",
-          "version": "1.3.2"
+          "revision": "e2bc81be54d71d566a52ca17c3983d141c30aa70",
+          "version": "1.3.3"
         }
       },
       {
@@ -384,8 +384,8 @@
         "repositoryURL": "https://github.com/spotify/xclogparser",
         "state": {
           "branch": null,
-          "revision": "ab85951bc54bfcbae27b2b1f22097e955f8e41e5",
-          "version": "0.2.24"
+          "revision": "171247366dd1bcd9bf61f9699867b18282eea842",
+          "version": "0.2.27"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
         .library(name: "XCMetricsUtils", targets: ["XCMetricsUtils"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/spotify/xclogparser", from: "0.2.24"),
+        .package(url: "https://github.com/spotify/xclogparser", from: "0.2.27"),
         .package(url: "https://github.com/apple/swift-package-manager.git", .exact("0.3.0")),
         .package(url: "https://github.com/grpc/grpc-swift.git", .exact("1.0.0-alpha.9")),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.23.0"),
@@ -25,7 +25,6 @@ let package = Package(
         .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", from: "1.3.0"),
         .package(url: "https://github.com/jpsim/Yams.git", from: "3.0.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "0.1.0"),
-
         .package(url: "https://github.com/vapor/vapor.git", from: "4.0.0"),
         .package(url: "https://github.com/vapor/fluent.git", from: "4.0.0"),
         .package(url: "https://github.com/vapor/fluent-postgres-driver.git", from: "2.1.0"),
@@ -38,7 +37,18 @@ let package = Package(
     targets: [
         .target(
             name: "XCMetricsClient",
-            dependencies: ["XCLogParser", "XCMetricsProto", "XCMetricsUtils", .product(name: "Utility", package: "SwiftPM"), "GRPC", "NIO", "NIOHTTP2", "MobiusCore", "MobiusExtras", "CryptoSwift", "Yams",  "ArgumentParser"]
+            dependencies: ["XCLogParser",
+                           "XCMetricsProto",
+                           "XCMetricsUtils",
+                           "GRPC",
+                           "NIO",
+                           "NIOHTTP2",
+                           "MobiusCore",
+                           "MobiusExtras",
+                           "CryptoSwift",
+                           "Yams",
+                           "ArgumentParser",
+                           "XCMetricsCommon"]
         ),
         .target(
             name: "XCMetricsPlugins",
@@ -56,6 +66,10 @@ let package = Package(
             name: "XCMetricsApp",
             dependencies: ["XCMetricsClient"]
         ),
+        .target(
+            name: "XCMetricsCommon",
+            dependencies: []
+        ),
        .target(
             name: "XCMetricsBackendLib",
             dependencies: [
@@ -69,6 +83,7 @@ let package = Package(
                 .product(name: "CryptoSwift", package: "CryptoSwift"),
                 .product(name: "GoogleCloudKit", package: "google-cloud-kit"),
                 .product(name: "S3", package: "AWSSDKSwift"),
+                "XCMetricsCommon"
             ],
             swiftSettings: [
                 // Enable better optimizations when building in Release configuration. Despite the use of
@@ -80,7 +95,7 @@ let package = Package(
         .target(name: "XCMetricsBackend", dependencies: [.target(name: "XCMetricsBackendLib")]),
         .testTarget(
             name: "XCMetricsTests",
-            dependencies: ["XCMetricsClient", "XCMetricsProto", .product(name: "Utility", package: "SwiftPM"), "MobiusTest"]
+            dependencies: ["XCMetricsClient", "XCMetricsProto", "MobiusTest", .product(name: "Utility", package: "SwiftPM")]
         ),
         .testTarget(
             name: "XCMetricsPluginsTests",

--- a/Sources/XCMetricsBackendLib/Config/Configuration.swift
+++ b/Sources/XCMetricsBackendLib/Config/Configuration.swift
@@ -5,7 +5,7 @@ class Configuration {
 
     /// If "1", the logs will be processed Asynchronously, it will need a `REDIS_HOST` to be defined
     /// Turn it off in environments where Async processing is not available like in Cloud Run
-    lazy var useAsyncLogProcessing: Bool = {
+    lazy var useAsyncLogProcessing: Bool = {        
         return (Environment.get("XCMETRICS_USE_ASYNC_LOG_PROCESSING") ?? "1" ) == "1"
     }()
 

--- a/Sources/XCMetricsBackendLib/UploadMetrics/LogProcessing/LogParser.swift
+++ b/Sources/XCMetricsBackendLib/UploadMetrics/LogProcessing/LogParser.swift
@@ -48,10 +48,15 @@ struct LogParser {
         userId: String,
         userIdSHA256: String,
         isCI: Bool,
-        sleepTime: Int?
+        sleepTime: Int?,
+        skipNotes: Bool?
     ) throws -> BuildMetrics {
         let activityLog = try ActivityParser().parseActivityLogInURL(url, redacted: true, withoutBuildSpecificInformation: true)
-        let buildSteps = try ParserBuildSteps(machineName: machineName, omitWarningsDetails: false).parse(activityLog: activityLog).flatten()
+        let buildSteps = try ParserBuildSteps(machineName: machineName,
+                                              omitWarningsDetails: false,
+                                              omitNotesDetails: skipNotes ?? false)
+            .parse(activityLog: activityLog)
+            .flatten()
         return toBuildMetrics(
             buildSteps,
             projectName: projectName,

--- a/Sources/XCMetricsBackendLib/UploadMetrics/LogProcessing/MetricsProcessor.swift
+++ b/Sources/XCMetricsBackendLib/UploadMetrics/LogProcessing/MetricsProcessor.swift
@@ -17,7 +17,8 @@ struct MetricsProcessor {
             userId: userId,
             userIdSHA256: userIdSHA256,
             isCI: isCI,
-            sleepTime: metricsRequest.extraInfo.sleepTime
+            sleepTime: metricsRequest.extraInfo.sleepTime,
+            skipNotes: metricsRequest.extraInfo.skipNotes
         )
     }
 

--- a/Sources/XCMetricsBackendLib/UploadMetrics/Model/UploadMetricsModel.swift
+++ b/Sources/XCMetricsBackendLib/UploadMetrics/Model/UploadMetricsModel.swift
@@ -19,6 +19,7 @@
 
 import Foundation
 import Vapor
+import XCMetricsCommon
 
 /// Content of a Multipart request to upload Metrics
 final class UploadMetricsPayload: Content {
@@ -47,7 +48,7 @@ final class UploadMetricsRequest: Codable {
     let logURL: URL
 
     /// Extra data needed
-    let extraInfo: ExtraInfo
+    let extraInfo: UploadRequestExtraInfo
 
     /// Build host information
     let buildHost: BuildHost
@@ -59,7 +60,7 @@ final class UploadMetricsRequest: Codable {
     let buildMetadata: BuildMetadata?
 
     init(logURL : URL,
-         extraInfo: ExtraInfo,
+         extraInfo: UploadRequestExtraInfo,
          buildHost: BuildHost,
          xcodeVersion: XcodeVersion?,
          buildMetadata: BuildMetadata?) {
@@ -78,7 +79,7 @@ final class UploadMetricsRequest: Codable {
     convenience init?(logURL: URL, payload: UploadMetricsPayload) throws {
         let decoder = JSONDecoder()
 
-        let extraInfo = try decoder.decode(ExtraInfo.self, from: payload.extraInfo.xcm_onlyJsonContent())
+        let extraInfo = try decoder.decode(UploadRequestExtraInfo.self, from: payload.extraInfo.xcm_onlyJsonContent())
         let buildHost = try decoder.decode(BuildHost.self, from: payload.buildHost.xcm_onlyJsonContent())
         let xcodeVersion: XcodeVersion?
         if let xcodeVersionData = payload.xcodeVersion?.xcm_onlyJsonContent() {
@@ -99,25 +100,6 @@ final class UploadMetricsRequest: Codable {
                   buildMetadata: buildMetadata)
 
     }
-}
-
-/// Data needed from the client that did the build
-final class ExtraInfo: Codable {
-
-    /// Name of the Xcode project
-    let projectName: String
-
-    /// Name of the host where the build was done
-    let machineName: String
-
-    /// Name of the user that did the build
-    let user: String
-
-    /// True if the build was performed on a continuous integration machine, false otherwise.
-    let isCI: Bool
-
-    /// The last time the host went to sleep as reported by sysctl's `kern.sleeptime` property.
-    let sleepTime: Int?
 }
 
 extension ByteBuffer {

--- a/Sources/XCMetricsClient/Log Management/LogParser.swift
+++ b/Sources/XCMetricsClient/Log Management/LogParser.swift
@@ -72,7 +72,10 @@ class LogParserImplementation: LogParser {
         dispatchQueue.async {
             do {
                 let activityLog = try ActivityParser().parseActivityLogInURL(logURL, redacted: true, withoutBuildSpecificInformation: true)
-                let buildSteps = try ParserBuildSteps(machineName: self.machineNameReader.machineName, omitWarningsDetails: false).parse(activityLog: activityLog).flatten()
+                let buildSteps = try ParserBuildSteps(machineName: self.machineNameReader.machineName,
+                                                      omitWarningsDetails: false,
+                                                      omitNotesDetails: false)
+                    .parse(activityLog: activityLog).flatten()
                 let uploadRequest = self.parseBuildSteps(buildSteps, projectName: projectName, isCI: isCI, userID: userID)
                 completion(.success(uploadRequest))
             } catch {

--- a/Sources/XCMetricsClient/Mobius/Domain/MetricsUploaderControllerFactory.swift
+++ b/Sources/XCMetricsClient/Mobius/Domain/MetricsUploaderControllerFactory.swift
@@ -34,7 +34,8 @@ enum ControllerFactory {
             serviceURL: serviceURL,
             timeout: command.timeout,
             isCI: command.isCI,
-            plugins: plugins
+            plugins: plugins,
+            skipNotes: command.skipNotes
         )
         let initEffect = MetricsUploaderEffect.findLogs(buildDirectory: model.buildDirectory, timeout: model.timeout)
         let logManager = LogManagerImplementation(projectName: model.projectName)

--- a/Sources/XCMetricsClient/Mobius/Domain/MetricsUploaderLogic.swift
+++ b/Sources/XCMetricsClient/Mobius/Domain/MetricsUploaderLogic.swift
@@ -82,7 +82,11 @@ enum MetricsUploaderLogic {
         })
 
         if !uploadRequests.isEmpty {
-            effects.append(.uploadLogs(serviceURL: model.serviceURL, projectName: model.projectName, isCI: model.isCI, logs: uploadRequests))
+            effects.append(.uploadLogs(serviceURL: model.serviceURL,
+                                       projectName: model.projectName,
+                                       isCI: model.isCI,
+                                       skipNotes: model.skipNotes,
+                                       logs: uploadRequests))
         }
         let updatedModel = model.withChanged(
             parsedRequests: model.parsedRequests.union(cachedUploadRequest.prefix(maximumNumberOfParsedRequestsToSend)),
@@ -94,6 +98,7 @@ enum MetricsUploaderLogic {
                 serviceURL: model.serviceURL,
                 projectName: model.projectName,
                 isCI: model.isCI,
+                skipNotes: model.skipNotes,
                 logs: updatedModel.parsedRequests
             )])
         }
@@ -111,6 +116,7 @@ enum MetricsUploaderLogic {
                 serviceURL: model.serviceURL,
                 projectName: model.projectName,
                 isCI: model.isCI,
+                skipNotes: model.skipNotes,
                 logs: updatedModel.parsedRequests
             )
         ])

--- a/Sources/XCMetricsClient/Mobius/Domain/MetricsUploaderLoopTypes.swift
+++ b/Sources/XCMetricsClient/Mobius/Domain/MetricsUploaderLoopTypes.swift
@@ -52,7 +52,7 @@ struct MetricsUploaderModel: Equatable, Hashable {
         plugins: [XCMetricsPlugin],
         parsedRequests: Set<MetricsUploadRequest> = Set(),
         awaitingParsingLogResponses: Int = 0,
-        skipNotes: Bool
+        skipNotes: Bool = false
     ) {
         self.buildDirectory = buildDirectory
         self.projectName = projectName

--- a/Sources/XCMetricsClient/Mobius/Domain/MetricsUploaderLoopTypes.swift
+++ b/Sources/XCMetricsClient/Mobius/Domain/MetricsUploaderLoopTypes.swift
@@ -40,6 +40,8 @@ struct MetricsUploaderModel: Equatable, Hashable {
     let parsedRequests: Set<MetricsUploadRequest>
     /// Number of scheduled parsing logs in progress
     let awaitingParsingResultsCount: Int
+    /// If true, the Notes found in the log won't be inserted into the database
+    let skipNotes: Bool
 
     init(
         buildDirectory: String,
@@ -49,7 +51,8 @@ struct MetricsUploaderModel: Equatable, Hashable {
         isCI: Bool,
         plugins: [XCMetricsPlugin],
         parsedRequests: Set<MetricsUploadRequest> = Set(),
-        awaitingParsingLogResponses: Int = 0
+        awaitingParsingLogResponses: Int = 0,
+        skipNotes: Bool
     ) {
         self.buildDirectory = buildDirectory
         self.projectName = projectName
@@ -59,6 +62,7 @@ struct MetricsUploaderModel: Equatable, Hashable {
         self.isCI = isCI
         self.parsedRequests = parsedRequests
         self.awaitingParsingResultsCount = awaitingParsingLogResponses
+        self.skipNotes = skipNotes
     }
 
     init() {
@@ -70,6 +74,7 @@ struct MetricsUploaderModel: Equatable, Hashable {
         self.isCI = false
         self.parsedRequests = []
         self.awaitingParsingResultsCount = 0
+        self.skipNotes = false
     }
 }
 
@@ -84,6 +89,7 @@ extension MetricsUploaderModel: CustomDebugStringConvertible {
         isCI: \(isCI),
         parsedRequests: \(parsedRequests.count),
         awaitingParsingLogResponses: \(awaitingParsingResultsCount)
+        skipNotes: \(skipNotes)
         """
     }
 }
@@ -148,7 +154,7 @@ enum MetricsUploaderEffect: Hashable {
     /// Executes the custom plugins configured if any to add more data to the build.
     case executePlugins(request: MetricsUploadRequest, plugins: [XCMetricsPlugin])
     /// Uploads the given log upload requests to the specified backend service.
-    case uploadLogs(serviceURL: URL, projectName: String, isCI: Bool, logs: Set<MetricsUploadRequest>)
+    case uploadLogs(serviceURL: URL, projectName: String, isCI: Bool, skipNotes: Bool, logs: Set<MetricsUploadRequest>)
     /// Uploaded logs should be renamed to signal their status and differentiate them from logs yet to be uploaded.
     case tagLogsAsUploaded(logs: Set<URL>)
     /// Logs failed to upload are saved to disk in order to preserve the metadata collected (the actual xcactivitylog is always kept on disk for 7 days).

--- a/Sources/XCMetricsClient/Mobius/Effect Handlers/DumpParser/JSONMetricsParserFactory.swift
+++ b/Sources/XCMetricsClient/Mobius/Effect Handlers/DumpParser/JSONMetricsParserFactory.swift
@@ -91,7 +91,8 @@ class JSONMetricsParserFactory: MetricsParserFactory {
                              compilationEndTimestamp: representation.fetch("compilationEndTimestamp"),
                              compilationDuration: representation.fetch("compilationDuration"),
                              clangTimeTraceFile: nil,
-                             linkerStatistics: nil)
+                             linkerStatistics: nil,
+                             swiftTypeCheckTimes: nil)
             return BuildInfo(step: step,
                              projectName: representation.fetch("projectName"),
                              userID: representation.fetch("userID"))

--- a/Sources/XCMetricsClient/Mobius/Effect Handlers/DumpParser/SchemaTypeBuilders.swift
+++ b/Sources/XCMetricsClient/Mobius/Effect Handlers/DumpParser/SchemaTypeBuilders.swift
@@ -76,7 +76,8 @@ extension BuildStep {
                          compilationEndTimestamp: compilationEndTimestamp ?? self.compilationEndTimestamp,
                          compilationDuration: compilationDuration ?? self.compilationDuration,
                          clangTimeTraceFile: nil,
-                         linkerStatistics: nil)
+                         linkerStatistics: nil,
+                         swiftTypeCheckTimes: nil)
     }
 }
 

--- a/Sources/XCMetricsClient/Mobius/Effect Handlers/UploadMetricsEffectHandler.swift
+++ b/Sources/XCMetricsClient/Mobius/Effect Handlers/UploadMetricsEffectHandler.swift
@@ -30,12 +30,14 @@ struct UploadMetricsEffectHandler: EffectHandler {
         self.metricsPublisher = metricsPublisher
     }
 
-    func handle(_ effectParameters: (serviceURL: URL, projectName: String, isCI: Bool, logs: Set<MetricsUploadRequest>), _ callback: EffectCallback<MetricsUploaderEvent>) -> Disposable {
+    func handle(_ effectParameters: (serviceURL: URL, projectName: String, isCI: Bool, skipNotes: Bool,
+                                     logs: Set<MetricsUploadRequest>), _ callback: EffectCallback<MetricsUploaderEvent>) -> Disposable {
         log("Started uploading metrics.")
         metricsPublisher.uploadMetrics(
             serviceURL: effectParameters.serviceURL,
             projectName: effectParameters.projectName,
             isCI: effectParameters.isCI,
+            skipNotes: effectParameters.skipNotes,
             uploadRequests: effectParameters.logs) { successfulURLs, failedURLs in
             var effects = [MetricsUploaderEvent]()
             // Handle failed log uploads. Skip if empty.

--- a/Sources/XCMetricsClient/Network/MetricsPublisherService.swift
+++ b/Sources/XCMetricsClient/Network/MetricsPublisherService.swift
@@ -30,10 +30,13 @@ protocol MetricsPublisherService {
     /// - Parameter uploadRequests: The upload requests to be sent to the backend service.
     /// - Parameter completion: The result is successfull if no error occurred. The .success enum case contains the URLs of the uploaded metrics.
     /// - Parameter projectName: The name of the project
+    /// - Parameter isCI: Boolean. If XCMetrics is running in CI or note
+    /// - Parameter skipNotes: Boolean. If the Notes found in the log won't be inserted in the database
     func uploadMetrics(
         serviceURL: URL,
         projectName: String,
         isCI: Bool,
+        skipNotes: Bool,
         uploadRequests: Set<MetricsUploadRequest>,
         completion: @escaping (_ successfulURLs: Set<URL>, _ failedURLs: [URL: Data]) -> Void
     )

--- a/Sources/XCMetricsClient/Network/MetricsPublisherServiceHTTP.swift
+++ b/Sources/XCMetricsClient/Network/MetricsPublisherServiceHTTP.swift
@@ -39,6 +39,7 @@ public class MetricsPublisherServiceHTTP: MetricsPublisherService {
         serviceURL: URL,
         projectName: String,
         isCI: Bool,
+        skipNotes: Bool,
         uploadRequests: Set<MetricsUploadRequest>,
         completion: @escaping (_ successfulURLs: Set<URL>, _ failedURLs: [URL: Data]) -> Void
     ) {
@@ -49,7 +50,7 @@ public class MetricsPublisherServiceHTTP: MetricsPublisherService {
         for uploadRequest in uploadRequests {
             self.dispatchGroup.enter()
 
-            self.uploadLog(uploadRequest, to: serviceURL, projectName: projectName, isCI: isCI) { (result: Result<Void, LogUploadError>) in
+            self.uploadLog(uploadRequest, to: serviceURL, projectName: projectName, isCI: isCI, skipNotes: skipNotes) { (result: Result<Void, LogUploadError>) in
                 switch result {
                 case .success:
                     successfulURLsLock.lock()
@@ -81,6 +82,7 @@ public class MetricsPublisherServiceHTTP: MetricsPublisherService {
         to requestUrl: URL,
         projectName: String,
         isCI: Bool,
+        skipNotes: Bool,
         completion: @escaping (Result<Void, LogUploadError>) -> Void
     ) {
         /// We send the unencrypted machine name, the backend will decide if is going to store it encrypted or not
@@ -91,7 +93,8 @@ public class MetricsPublisherServiceHTTP: MetricsPublisherService {
                            url: requestUrl,
                            machineName: machineName,
                            projectName: projectName,
-                           isCI: isCI).build()
+                           isCI: isCI,
+                           skipNotes: skipNotes).build()
 
             getURLSession().dataTask(with: request) { (data, response, error) in
                 defer {

--- a/Sources/XCMetricsClient/Network/MetricsRequest.swift
+++ b/Sources/XCMetricsClient/Network/MetricsRequest.swift
@@ -19,28 +19,6 @@
 
 import Foundation
 
-/// Info from the current build that is not in the Log and that is needed by the backend
-final class ExtraInfo: Encodable {
-
-    let projectName: String
-
-    let machineName: String
-
-    let user: String
-
-    let isCI: Bool
-
-    let sleepTime: Int
-
-    init(projectName: String, machineName: String, user: String, isCI: Bool, sleepTime: Int) {
-        self.projectName = projectName
-        self.machineName = machineName
-        self.user = user
-        self.isCI = isCI
-        self.sleepTime = sleepTime
-    }
-}
-
 extension BuildHost: Encodable {
     enum CodingKeys: String, CodingKey {
         case buildIdentifier

--- a/Sources/XCMetricsClient/Network/MultipartRequestBuilder.swift
+++ b/Sources/XCMetricsClient/Network/MultipartRequestBuilder.swift
@@ -18,6 +18,7 @@
 // under the License.
 
 import Foundation
+import XCMetricsCommon
 
 /// Creates a Nested Multipart Request to send the
 /// `xcactivitylog` and the Metadata associated to it as `JSON` documents
@@ -29,13 +30,20 @@ class MultipartRequestBuilder {
     public let machineName: String
     public let projectName: String
     public let isCI: Bool
+    public let skipNotes: Bool
 
-    public init(request: MetricsUploadRequest, url: URL, machineName: String, projectName: String, isCI: Bool) {
+    public init(request: MetricsUploadRequest,
+                url: URL,
+                machineName: String,
+                projectName: String,
+                isCI: Bool,
+                skipNotes: Bool) {
         self.request = request
         self.url = url
         self.machineName = machineName
         self.projectName = projectName
         self.isCI = isCI
+        self.skipNotes = skipNotes
     }
 
     public func build() throws -> URLRequest {
@@ -72,8 +80,12 @@ class MultipartRequestBuilder {
         /// Backend will decide if the username will be stored hashed or not based on its configuration
         let user = MacOSUsernameReader().userID ?? "unknown"
         let sleepTime = HardwareFactsFetcherImplementation().sleepTime
-        let extraInfo = ExtraInfo(projectName: projectName, machineName: machineName, user: user, isCI: isCI,
-                                  sleepTime: sleepTime)
+        let extraInfo = UploadRequestExtraInfo(projectName: projectName,
+                                                machineName: machineName,
+                                                user: user,
+                                                isCI: isCI,
+                                                sleepTime: sleepTime,
+                                                skipNotes: skipNotes)
         let extraJson = try jsonEncoder.encode(extraInfo)
         if let extraData = toJSONFormField(named: "extraInfo", jsonData: extraJson, using: boundary) {
           httpBody.append(extraData)

--- a/Sources/XCMetricsClient/Utils/MetricsUploaderModel+Utils.swift
+++ b/Sources/XCMetricsClient/Utils/MetricsUploaderModel+Utils.swift
@@ -33,7 +33,8 @@ extension MetricsUploaderModel {
             isCI: self.isCI,
             plugins: self.plugins,
             parsedRequests: parsedRequests ?? self.parsedRequests,
-            awaitingParsingLogResponses: awaitingParsingLogResponses ?? self.awaitingParsingResultsCount
+            awaitingParsingLogResponses: awaitingParsingLogResponses ?? self.awaitingParsingResultsCount,
+            skipNotes: self.skipNotes
         )
     }
 }

--- a/Sources/XCMetricsClient/XCMetrics.swift
+++ b/Sources/XCMetricsClient/XCMetrics.swift
@@ -71,6 +71,7 @@ struct Command {
     let timeout: Int
     let serviceURL: String
     let isCI: Bool
+    let skipNotes: Bool
 }
 
 
@@ -103,13 +104,18 @@ public struct XCMetrics: ParsableCommand {
     @Option(name: [.customLong("isCI")], help: "If the metrics collected are coming from CI or not.")
     public var isCI: Bool = false
 
+    /// If the Notes found in log should be skipped. Useful when there are thousands of notes to
+    /// reduce the size of the Database.
+    @Option(name: [.customLong("skipNotes")], help: "Notes found in logs won't be processed")
+    public var skipNotes: Bool = false
+
     private static let loop = XCMetricsLoop()
 
     /// The default initializer for the `XCMetrics` object.
     public init() {}
 
     /// Runs XCMetrics with the provided configuration containing the optional custom plugins to be executed.
-    /// - Parameter configuration: <#configuration description#>
+    /// - Parameter configuration: `XCMetricsConfiguration`
     public func run(with configuration: XCMetricsConfiguration) {
         do {
             let command = try fetchEnvironmentVariablesParameters()
@@ -132,6 +138,7 @@ public struct XCMetrics: ParsableCommand {
         If a $BUILD_DIR environment variable is defined, you can omit --buildDir.
         The --timeout argument is optional and defaults to 5 seconds.
         The --isCI argument is optional and defaults to false.
+        The --skipNotes argument is optional and defaults to false.
         Type 'XCMetrics --help' for more information.
         """)
     }
@@ -166,7 +173,8 @@ public struct XCMetrics: ParsableCommand {
             projectName: name,
             timeout: timeout,
             serviceURL: serviceURLValue,
-            isCI: isCI
+            isCI: isCI,
+            skipNotes: skipNotes
         )
         return command
     }

--- a/Sources/XCMetricsCommon/UploadRequestExtraInfo.swift
+++ b/Sources/XCMetricsCommon/UploadRequestExtraInfo.swift
@@ -1,0 +1,56 @@
+// Copyright (c) 2020 Spotify AB.
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/// Data needed from the client that did the build
+public final class UploadRequestExtraInfo: Codable {
+
+    /// Name of the Xcode project
+    public let projectName: String
+
+    /// Name of the host where the build was done
+    public let machineName: String
+
+    /// Name of the user that did the build
+    public let user: String
+
+    /// True if the build was performed on a continuous integration machine, false otherwise.
+    public let isCI: Bool
+
+    /// The last time the host went to sleep as reported by sysctl's `kern.sleeptime` property.
+    public let sleepTime: Int?
+
+    /// Don't process the Notes found in the log
+    /// In some cases, we can have thousands of these that can make database grow exponentially
+    /// while providing little value
+    public let skipNotes: Bool?
+
+    public init(projectName: String,
+                machineName: String,
+                user: String,
+                isCI: Bool,
+                sleepTime: Int?,
+                skipNotes: Bool?) {
+        self.projectName = projectName
+        self.machineName = machineName
+        self.user = user
+        self.isCI = isCI
+        self.sleepTime = sleepTime
+        self.skipNotes = skipNotes
+    }
+}

--- a/Tests/XCMetricsTests/Effect Handlers/UploadMetricsEffectHandlerTests.swift
+++ b/Tests/XCMetricsTests/Effect Handlers/UploadMetricsEffectHandlerTests.swift
@@ -29,6 +29,7 @@ final class MockMetricsPublisher: MetricsPublisherService {
         serviceURL: URL,
         projectName: String,
         isCI: Bool,
+        skipNotes: Bool,
         uploadRequests: Set<MetricsUploadRequest>,
         completion: @escaping (Set<URL>, [URL : Data]) -> Void
     ) {
@@ -72,7 +73,8 @@ final class UploadMetricsEffectHandlerTests: XCTestCase {
                 XCTFail("Expected .logsUploaded or , got: \(event)")
             }
         }
-        _ = effectHandler.handle((serviceURL: serviceURL, projectName: projectName, isCI: false, logs: uploadRequests), effectCallback)
+        _ = effectHandler.handle((serviceURL: serviceURL, projectName: projectName, isCI: false, skipNotes: false, logs: uploadRequests),
+                                 effectCallback)
         XCTAssertTrue(effectCallback.ended)
     }
 }

--- a/Tests/XCMetricsTests/MetricsUploaderLogicTests.swift
+++ b/Tests/XCMetricsTests/MetricsUploaderLogicTests.swift
@@ -47,7 +47,8 @@ class MetricsUploaderLogicTests: XCTestCase {
                                                serviceURL: serviceURL,
                                                timeout: 1,
                                                isCI: false,
-                                               plugins: [])
+                                               plugins: [],
+                                               skipNotes: false)
 
     func testInitiator() {
         let initEffect = MetricsUploaderEffect.findLogs(buildDirectory: initial.buildDirectory, timeout: 1)
@@ -83,6 +84,7 @@ class MetricsUploaderLogicTests: XCTestCase {
                         serviceURL: serviceURL,
                         projectName: projectName,
                         isCI: false,
+                        skipNotes: false,
                         logs: Set([MetricsUploadRequest(fileURL: cachedLog, request: UploadBuildMetricsRequest())])
                     )
                 ])
@@ -109,6 +111,7 @@ class MetricsUploaderLogicTests: XCTestCase {
                         serviceURL: serviceURL,
                         projectName: projectName,
                         isCI: false,
+                        skipNotes: false,
                         logs: Set([
                             MetricsUploadRequest(fileURL: cachedLog, request: UploadBuildMetricsRequest())
                         ])

--- a/docs/Getting Started.md
+++ b/docs/Getting Started.md
@@ -48,6 +48,7 @@ This is how the post-action scheme should look like. Let's break it down:
 	- `--serviceURL`: the URL of the service receiving the collected metrics. If you haven't deployed a service yet, please head over to ["Deploy Backend"](https://github.com/spotify/XCMetrics/blob/main/docs/How%20to%20Deploy%20Backend.md) first.
     - `--timeout`: the number of seconds to wait for the Xcode log to appear. The default value is 5s.
     - `--isCI`: either true or false based on if the current build is running on CI or not. This is useful to categorize builds as local or continuous integration builds.
+    - `--skipNotes`: true or false. If true, the Notes found in a log (Xcode adds them to with things like the output of Post build phase's scripts like Swiftlint) won't be inserted in the Database. Useful if you have thousands of these in your log and want to save some space. 
 
 ![](img/post-action-scheme.png)
 


### PR DESCRIPTION
In some cases, a log can contain thousands of Notes. For instance, if it has a lot of modules and is running SwiftLint as a PostBuild Phase's script. Inserting this data to the Database, can make it grow exponentially.

This PR adds an option: `--skipNotes false` that can be passed to the `XCMetrics` command so all those notes won't be inserted.