### PR TITLE
Facilitate additional auth headers to be included within the metrics request

### DIFF
--- a/Sources/XCMetricsClient/Mobius/Domain/MetricsUploaderControllerFactory.swift
+++ b/Sources/XCMetricsClient/Mobius/Domain/MetricsUploaderControllerFactory.swift
@@ -32,6 +32,7 @@ enum ControllerFactory {
             buildDirectory: command.buildDirectory,
             projectName: command.projectName,
             serviceURL: serviceURL,
+            authorizationHeader: command.authorizationHeader,
             timeout: command.timeout,
             isCI: command.isCI,
             plugins: plugins

--- a/Sources/XCMetricsClient/Mobius/Domain/MetricsUploaderControllerFactory.swift
+++ b/Sources/XCMetricsClient/Mobius/Domain/MetricsUploaderControllerFactory.swift
@@ -32,7 +32,7 @@ enum ControllerFactory {
             buildDirectory: command.buildDirectory,
             projectName: command.projectName,
             serviceURL: serviceURL,
-            authorizationHeader: command.authorizationHeader,
+            additionalHeaders: command.additionalHeaders,
             timeout: command.timeout,
             isCI: command.isCI,
             plugins: plugins

--- a/Sources/XCMetricsClient/Mobius/Domain/MetricsUploaderLogic.swift
+++ b/Sources/XCMetricsClient/Mobius/Domain/MetricsUploaderLogic.swift
@@ -82,7 +82,13 @@ enum MetricsUploaderLogic {
         })
 
         if !uploadRequests.isEmpty {
-            effects.append(.uploadLogs(serviceURL: model.serviceURL, projectName: model.projectName, isCI: model.isCI, logs: uploadRequests))
+            effects.append(.uploadLogs(
+                serviceURL: model.serviceURL,
+                authorizationHeader: model.authorizationHeader,
+                projectName: model.projectName,
+                isCI: model.isCI,
+                logs: uploadRequests
+            ))
         }
         let updatedModel = model.withChanged(
             parsedRequests: model.parsedRequests.union(cachedUploadRequest.prefix(maximumNumberOfParsedRequestsToSend)),
@@ -92,6 +98,7 @@ enum MetricsUploaderLogic {
         if effects.isEmpty {
             return .next(updatedModel, effects: [.uploadLogs(
                 serviceURL: model.serviceURL,
+                authorizationHeader: model.authorizationHeader,
                 projectName: model.projectName,
                 isCI: model.isCI,
                 logs: updatedModel.parsedRequests
@@ -109,6 +116,7 @@ enum MetricsUploaderLogic {
         return .next(updatedModel, effects: [
             .uploadLogs(
                 serviceURL: model.serviceURL,
+                authorizationHeader: model.authorizationHeader,
                 projectName: model.projectName,
                 isCI: model.isCI,
                 logs: updatedModel.parsedRequests

--- a/Sources/XCMetricsClient/Mobius/Domain/MetricsUploaderLogic.swift
+++ b/Sources/XCMetricsClient/Mobius/Domain/MetricsUploaderLogic.swift
@@ -84,7 +84,7 @@ enum MetricsUploaderLogic {
         if !uploadRequests.isEmpty {
             effects.append(.uploadLogs(
                 serviceURL: model.serviceURL,
-                authorizationHeader: model.authorizationHeader,
+                additionalHeaders: model.additionalHeaders,
                 projectName: model.projectName,
                 isCI: model.isCI,
                 logs: uploadRequests
@@ -98,7 +98,7 @@ enum MetricsUploaderLogic {
         if effects.isEmpty {
             return .next(updatedModel, effects: [.uploadLogs(
                 serviceURL: model.serviceURL,
-                authorizationHeader: model.authorizationHeader,
+                additionalHeaders: model.additionalHeaders,
                 projectName: model.projectName,
                 isCI: model.isCI,
                 logs: updatedModel.parsedRequests
@@ -116,7 +116,7 @@ enum MetricsUploaderLogic {
         return .next(updatedModel, effects: [
             .uploadLogs(
                 serviceURL: model.serviceURL,
-                authorizationHeader: model.authorizationHeader,
+                additionalHeaders: model.additionalHeaders,
                 projectName: model.projectName,
                 isCI: model.isCI,
                 logs: updatedModel.parsedRequests

--- a/Sources/XCMetricsClient/Mobius/Domain/MetricsUploaderLoopTypes.swift
+++ b/Sources/XCMetricsClient/Mobius/Domain/MetricsUploaderLoopTypes.swift
@@ -30,8 +30,8 @@ struct MetricsUploaderModel: Equatable, Hashable {
     let projectName: String
     /// The URL of the service where to send metrics to.
     let serviceURL: URL
-    /// An authorization header to be sent with the request.
-    let authorizationHeader: String?
+    /// Additional headers to be sent with the request.
+    let additionalHeaders: [String: String]
     /// The amount of seconds to wait for the Xcode's log to appear.
     let timeout: Int
     /// Whether or not this build was performed in a continuous integration environment.
@@ -47,7 +47,7 @@ struct MetricsUploaderModel: Equatable, Hashable {
         buildDirectory: String,
         projectName: String,
         serviceURL: URL,
-        authorizationHeader: String?,
+        additionalHeaders: [String: String],
         timeout: Int,
         isCI: Bool,
         plugins: [XCMetricsPlugin],
@@ -57,7 +57,7 @@ struct MetricsUploaderModel: Equatable, Hashable {
         self.buildDirectory = buildDirectory
         self.projectName = projectName
         self.serviceURL = serviceURL
-        self.authorizationHeader = authorizationHeader
+        self.additionalHeaders = additionalHeaders
         self.plugins = plugins
         self.timeout = timeout
         self.isCI = isCI
@@ -69,7 +69,7 @@ struct MetricsUploaderModel: Equatable, Hashable {
         self.buildDirectory = ""
         self.projectName = ""
         self.serviceURL = URL(string: "")!
-        self.authorizationHeader = nil
+        self.additionalHeaders = [:]
         self.plugins = []
         self.timeout = 0
         self.isCI = false
@@ -153,7 +153,7 @@ enum MetricsUploaderEffect: Hashable {
     /// Executes the custom plugins configured if any to add more data to the build.
     case executePlugins(request: MetricsUploadRequest, plugins: [XCMetricsPlugin])
     /// Uploads the given log upload requests to the specified backend service.
-    case uploadLogs(serviceURL: URL, authorizationHeader: String?, projectName: String, isCI: Bool, logs: Set<MetricsUploadRequest>)
+    case uploadLogs(serviceURL: URL, additionalHeaders: [String: String], projectName: String, isCI: Bool, logs: Set<MetricsUploadRequest>)
     /// Uploaded logs should be renamed to signal their status and differentiate them from logs yet to be uploaded.
     case tagLogsAsUploaded(logs: Set<URL>)
     /// Logs failed to upload are saved to disk in order to preserve the metadata collected (the actual xcactivitylog is always kept on disk for 7 days).

--- a/Sources/XCMetricsClient/Mobius/Domain/MetricsUploaderLoopTypes.swift
+++ b/Sources/XCMetricsClient/Mobius/Domain/MetricsUploaderLoopTypes.swift
@@ -30,6 +30,8 @@ struct MetricsUploaderModel: Equatable, Hashable {
     let projectName: String
     /// The URL of the service where to send metrics to.
     let serviceURL: URL
+    /// An authorization header to be sent with the request.
+    let authorizationHeader: String?
     /// The amount of seconds to wait for the Xcode's log to appear.
     let timeout: Int
     /// Whether or not this build was performed in a continuous integration environment.
@@ -45,6 +47,7 @@ struct MetricsUploaderModel: Equatable, Hashable {
         buildDirectory: String,
         projectName: String,
         serviceURL: URL,
+        authorizationHeader: String?,
         timeout: Int,
         isCI: Bool,
         plugins: [XCMetricsPlugin],
@@ -54,6 +57,7 @@ struct MetricsUploaderModel: Equatable, Hashable {
         self.buildDirectory = buildDirectory
         self.projectName = projectName
         self.serviceURL = serviceURL
+        self.authorizationHeader = authorizationHeader
         self.plugins = plugins
         self.timeout = timeout
         self.isCI = isCI
@@ -65,6 +69,7 @@ struct MetricsUploaderModel: Equatable, Hashable {
         self.buildDirectory = ""
         self.projectName = ""
         self.serviceURL = URL(string: "")!
+        self.authorizationHeader = nil
         self.plugins = []
         self.timeout = 0
         self.isCI = false
@@ -148,7 +153,7 @@ enum MetricsUploaderEffect: Hashable {
     /// Executes the custom plugins configured if any to add more data to the build.
     case executePlugins(request: MetricsUploadRequest, plugins: [XCMetricsPlugin])
     /// Uploads the given log upload requests to the specified backend service.
-    case uploadLogs(serviceURL: URL, projectName: String, isCI: Bool, logs: Set<MetricsUploadRequest>)
+    case uploadLogs(serviceURL: URL, authorizationHeader: String?, projectName: String, isCI: Bool, logs: Set<MetricsUploadRequest>)
     /// Uploaded logs should be renamed to signal their status and differentiate them from logs yet to be uploaded.
     case tagLogsAsUploaded(logs: Set<URL>)
     /// Logs failed to upload are saved to disk in order to preserve the metadata collected (the actual xcactivitylog is always kept on disk for 7 days).

--- a/Sources/XCMetricsClient/Mobius/Effect Handlers/UploadMetricsEffectHandler.swift
+++ b/Sources/XCMetricsClient/Mobius/Effect Handlers/UploadMetricsEffectHandler.swift
@@ -30,11 +30,11 @@ struct UploadMetricsEffectHandler: EffectHandler {
         self.metricsPublisher = metricsPublisher
     }
 
-    func handle(_ effectParameters: (serviceURL: URL, authorizationHeader: String?, projectName: String, isCI: Bool, logs: Set<MetricsUploadRequest>), _ callback: EffectCallback<MetricsUploaderEvent>) -> Disposable {
+    func handle(_ effectParameters: (serviceURL: URL, additionalHeaders: [String: String], projectName: String, isCI: Bool, logs: Set<MetricsUploadRequest>), _ callback: EffectCallback<MetricsUploaderEvent>) -> Disposable {
         log("Started uploading metrics.")
         metricsPublisher.uploadMetrics(
             serviceURL: effectParameters.serviceURL,
-            authorizationHeader: effectParameters.authorizationHeader,
+            additionalHeaders: effectParameters.additionalHeaders,
             projectName: effectParameters.projectName,
             isCI: effectParameters.isCI,
             uploadRequests: effectParameters.logs) { successfulURLs, failedURLs in

--- a/Sources/XCMetricsClient/Mobius/Effect Handlers/UploadMetricsEffectHandler.swift
+++ b/Sources/XCMetricsClient/Mobius/Effect Handlers/UploadMetricsEffectHandler.swift
@@ -30,10 +30,11 @@ struct UploadMetricsEffectHandler: EffectHandler {
         self.metricsPublisher = metricsPublisher
     }
 
-    func handle(_ effectParameters: (serviceURL: URL, projectName: String, isCI: Bool, logs: Set<MetricsUploadRequest>), _ callback: EffectCallback<MetricsUploaderEvent>) -> Disposable {
+    func handle(_ effectParameters: (serviceURL: URL, authorizationHeader: String?, projectName: String, isCI: Bool, logs: Set<MetricsUploadRequest>), _ callback: EffectCallback<MetricsUploaderEvent>) -> Disposable {
         log("Started uploading metrics.")
         metricsPublisher.uploadMetrics(
             serviceURL: effectParameters.serviceURL,
+            authorizationHeader: effectParameters.authorizationHeader,
             projectName: effectParameters.projectName,
             isCI: effectParameters.isCI,
             uploadRequests: effectParameters.logs) { successfulURLs, failedURLs in

--- a/Sources/XCMetricsClient/Network/MetricsPublisherService.swift
+++ b/Sources/XCMetricsClient/Network/MetricsPublisherService.swift
@@ -27,13 +27,13 @@ import XCMetricsProto
 protocol MetricsPublisherService {
     /// Upload the given metrics and returns the result in a completion block.
     /// - Parameter serviceURL: The URL of the backend service where the metrics will be sent.
-    /// - Parameter authorizationHeader: An authorization header to be sent with the request.
+    /// - Parameter additionalHeaders: Additional headers to be sent with the request.
     /// - Parameter uploadRequests: The upload requests to be sent to the backend service.
     /// - Parameter completion: The result is successful if no error occurred. The .success enum case contains the URLs of the uploaded metrics.
     /// - Parameter projectName: The name of the project
     func uploadMetrics(
         serviceURL: URL,
-        authorizationHeader: String?,
+        additionalHeaders: [String: String],
         projectName: String,
         isCI: Bool,
         uploadRequests: Set<MetricsUploadRequest>,

--- a/Sources/XCMetricsClient/Network/MetricsPublisherService.swift
+++ b/Sources/XCMetricsClient/Network/MetricsPublisherService.swift
@@ -26,12 +26,14 @@ import XCMetricsProto
 /// Defines the required methods for a publisher service.
 protocol MetricsPublisherService {
     /// Upload the given metrics and returns the result in a completion block.
-    /// - Parameter serviceURL: The URL of the backend service where the metrics wil be sent.
+    /// - Parameter serviceURL: The URL of the backend service where the metrics will be sent.
+    /// - Parameter authorizationHeader: An authorization header to be sent with the request.
     /// - Parameter uploadRequests: The upload requests to be sent to the backend service.
-    /// - Parameter completion: The result is successfull if no error occurred. The .success enum case contains the URLs of the uploaded metrics.
+    /// - Parameter completion: The result is successful if no error occurred. The .success enum case contains the URLs of the uploaded metrics.
     /// - Parameter projectName: The name of the project
     func uploadMetrics(
         serviceURL: URL,
+        authorizationHeader: String?,
         projectName: String,
         isCI: Bool,
         uploadRequests: Set<MetricsUploadRequest>,

--- a/Sources/XCMetricsClient/Network/MetricsPublisherServiceHTTP.swift
+++ b/Sources/XCMetricsClient/Network/MetricsPublisherServiceHTTP.swift
@@ -37,6 +37,7 @@ public class MetricsPublisherServiceHTTP: MetricsPublisherService {
 
     func uploadMetrics(
         serviceURL: URL,
+        authorizationHeader: String?,
         projectName: String,
         isCI: Bool,
         uploadRequests: Set<MetricsUploadRequest>,
@@ -49,7 +50,7 @@ public class MetricsPublisherServiceHTTP: MetricsPublisherService {
         for uploadRequest in uploadRequests {
             self.dispatchGroup.enter()
 
-            self.uploadLog(uploadRequest, to: serviceURL, projectName: projectName, isCI: isCI) { (result: Result<Void, LogUploadError>) in
+            self.uploadLog(uploadRequest, to: serviceURL, authorizationHeader: authorizationHeader, projectName: projectName, isCI: isCI) { (result: Result<Void, LogUploadError>) in
                 switch result {
                 case .success:
                     successfulURLsLock.lock()
@@ -79,6 +80,7 @@ public class MetricsPublisherServiceHTTP: MetricsPublisherService {
     private func uploadLog(
         _ uploadRequest: MetricsUploadRequest,
         to requestUrl: URL,
+        authorizationHeader: String?,
         projectName: String,
         isCI: Bool,
         completion: @escaping (Result<Void, LogUploadError>) -> Void
@@ -89,6 +91,7 @@ public class MetricsPublisherServiceHTTP: MetricsPublisherService {
         do {
             let request = try MultipartRequestBuilder(request: uploadRequest,
                            url: requestUrl,
+                           authorizationHeader: authorizationHeader,
                            machineName: machineName,
                            projectName: projectName,
                            isCI: isCI).build()

--- a/Sources/XCMetricsClient/Network/MultipartRequestBuilder.swift
+++ b/Sources/XCMetricsClient/Network/MultipartRequestBuilder.swift
@@ -26,13 +26,15 @@ class MultipartRequestBuilder {
 
     public let request: MetricsUploadRequest
     public let url: URL
+    public let authorizationHeader: String?
     public let machineName: String
     public let projectName: String
     public let isCI: Bool
 
-    public init(request: MetricsUploadRequest, url: URL, machineName: String, projectName: String, isCI: Bool) {
+    public init(request: MetricsUploadRequest, url: URL, authorizationHeader: String?, machineName: String, projectName: String, isCI: Bool) {
         self.request = request
         self.url = url
+        self.authorizationHeader = authorizationHeader
         self.machineName = machineName
         self.projectName = projectName
         self.isCI = isCI
@@ -44,6 +46,7 @@ class MultipartRequestBuilder {
         let boundary = "Boundary-\(uuid)"
         var request = URLRequest(url: url)
         request.httpMethod = "PUT"
+        authorizationHeader.flatMap { request.addValue($0, forHTTPHeaderField: "Authorization") }
         request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
         // If this is a retry for a previously failed request, simply set the body. Otherwise compute it.
         let body: Data

--- a/Sources/XCMetricsClient/Network/MultipartRequestBuilder.swift
+++ b/Sources/XCMetricsClient/Network/MultipartRequestBuilder.swift
@@ -26,15 +26,15 @@ class MultipartRequestBuilder {
 
     public let request: MetricsUploadRequest
     public let url: URL
-    public let authorizationHeader: String?
+    public let additionalHeaders: [String: String]
     public let machineName: String
     public let projectName: String
     public let isCI: Bool
 
-    public init(request: MetricsUploadRequest, url: URL, authorizationHeader: String?, machineName: String, projectName: String, isCI: Bool) {
+    public init(request: MetricsUploadRequest, url: URL, additionalHeaders: [String: String], machineName: String, projectName: String, isCI: Bool) {
         self.request = request
         self.url = url
-        self.authorizationHeader = authorizationHeader
+        self.additionalHeaders = additionalHeaders
         self.machineName = machineName
         self.projectName = projectName
         self.isCI = isCI
@@ -46,7 +46,7 @@ class MultipartRequestBuilder {
         let boundary = "Boundary-\(uuid)"
         var request = URLRequest(url: url)
         request.httpMethod = "PUT"
-        authorizationHeader.flatMap { request.addValue($0, forHTTPHeaderField: "Authorization") }
+        additionalHeaders.forEach { request.addValue($1, forHTTPHeaderField: $0) }
         request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
         // If this is a retry for a previously failed request, simply set the body. Otherwise compute it.
         let body: Data

--- a/Sources/XCMetricsClient/Utils/MetricsUploaderModel+Utils.swift
+++ b/Sources/XCMetricsClient/Utils/MetricsUploaderModel+Utils.swift
@@ -29,7 +29,7 @@ extension MetricsUploaderModel {
             buildDirectory: self.buildDirectory,
             projectName: self.projectName,
             serviceURL: self.serviceURL,
-            authorizationHeader: self.authorizationHeader,
+            additionalHeaders: self.additionalHeaders,
             timeout: self.timeout,
             isCI: self.isCI,
             plugins: self.plugins,

--- a/Sources/XCMetricsClient/Utils/MetricsUploaderModel+Utils.swift
+++ b/Sources/XCMetricsClient/Utils/MetricsUploaderModel+Utils.swift
@@ -29,6 +29,7 @@ extension MetricsUploaderModel {
             buildDirectory: self.buildDirectory,
             projectName: self.projectName,
             serviceURL: self.serviceURL,
+            authorizationHeader: self.authorizationHeader,
             timeout: self.timeout,
             isCI: self.isCI,
             plugins: self.plugins,

--- a/Sources/XCMetricsClient/XCMetrics.swift
+++ b/Sources/XCMetricsClient/XCMetrics.swift
@@ -111,11 +111,11 @@ public struct XCMetrics: ParsableCommand {
     public var skipNotes: Bool = false
 
     /// An optional authorization/token header **key** to be included in the upload request. Must be used in conjunction with `authorizationValue.`
-    @Option(name: [.customLong("authorizationKey"), .customShort("k")], help: "An optional authorization header key to be included in the upload request e.g 'Authorization' or 'x-api-key' etc.")
+    @Option(name: [.customLong("authorizationKey"), .customShort("k")], help: "An optional authorization header key to be included in the upload request e.g 'Authorization' or 'x-api-key' etc. Must be used in conjunction with `authorizationValue`")
     public var authorizationKey: String?
 
     /// An optional authorization/token header **value** to be included in the upload request. Must be used in conjunction with `authorizationKey.`
-    @Option(name: [.customLong("authorizationValue"), .customShort("a")], help: "An optional authorization header value to be included in the upload request e.g 'Basic YWxhZGRpbjpvcGVuc2VzYW1l' or `hYDqG78OIUDIWKLdwjdwhdu8` etc.")
+    @Option(name: [.customLong("authorizationValue"), .customShort("a")], help: "An optional authorization header value to be included in the upload request e.g 'Basic YWxhZGRpbjpvcGVuc2VzYW1l' or `hYDqG78OIUDIWKLdwjdwhdu8` etc. Must be used in conjunction with `authorizationKey`")
     public var authorizationValue: String?
 
     private static let loop = XCMetricsLoop()

--- a/Sources/XCMetricsClient/XCMetrics.swift
+++ b/Sources/XCMetricsClient/XCMetrics.swift
@@ -105,7 +105,7 @@ public struct XCMetrics: ParsableCommand {
     public var isCI: Bool = false
 
     /// An optional 'Authorization' header to be included in the upload request.
-    @Option(name: [.customLong("authorizationHeader"), .customShort("s")], help: "An optional 'Authorization' header to be included in the upload request.")
+    @Option(name: [.customLong("authorizationHeader"), .customShort("s")], help: "An optional 'Authorization' header to be included in the upload request e.g 'Basic YWxhZGRpbjpvcGVuc2VzYW1l'")
     public var authorizationHeader: String?
 
     private static let loop = XCMetricsLoop()

--- a/Sources/XCMetricsClient/XCMetrics.swift
+++ b/Sources/XCMetricsClient/XCMetrics.swift
@@ -71,6 +71,7 @@ struct Command {
     let timeout: Int
     let serviceURL: String
     let isCI: Bool
+    let authorizationHeader: String?
 }
 
 
@@ -102,6 +103,10 @@ public struct XCMetrics: ParsableCommand {
     /// If the metrics collected are coming from CI or not provided as argument. Default value is false.
     @Option(name: [.customLong("isCI")], help: "If the metrics collected are coming from CI or not.")
     public var isCI: Bool = false
+
+    /// An optional 'Authorization' header to be included in the upload request.
+    @Option(name: [.customLong("authorizationHeader"), .customShort("s")], help: "An optional 'Authorization' header to be included in the upload request.")
+    public var authorizationHeader: String?
 
     private static let loop = XCMetricsLoop()
 
@@ -166,7 +171,8 @@ public struct XCMetrics: ParsableCommand {
             projectName: name,
             timeout: timeout,
             serviceURL: serviceURLValue,
-            isCI: isCI
+            isCI: isCI,
+            authorizationHeader: authorizationHeader
         )
         return command
     }

--- a/Tests/XCMetricsTests/Effect Handlers/UploadMetricsEffectHandlerTests.swift
+++ b/Tests/XCMetricsTests/Effect Handlers/UploadMetricsEffectHandlerTests.swift
@@ -27,6 +27,7 @@ final class MockMetricsPublisher: MetricsPublisherService {
 
     func uploadMetrics(
         serviceURL: URL,
+        additionalHeaders: [String : String],
         projectName: String,
         isCI: Bool,
         uploadRequests: Set<MetricsUploadRequest>,
@@ -72,7 +73,7 @@ final class UploadMetricsEffectHandlerTests: XCTestCase {
                 XCTFail("Expected .logsUploaded or , got: \(event)")
             }
         }
-        _ = effectHandler.handle((serviceURL: serviceURL, projectName: projectName, isCI: false, logs: uploadRequests), effectCallback)
+        _ = effectHandler.handle((serviceURL: serviceURL, additionalHeaders: additionalHeaders, projectName: projectName, isCI: false, logs: uploadRequests), effectCallback)
         XCTAssertTrue(effectCallback.ended)
     }
 }

--- a/Tests/XCMetricsTests/MetricsUploaderLogicTests.swift
+++ b/Tests/XCMetricsTests/MetricsUploaderLogicTests.swift
@@ -38,6 +38,7 @@ extension TemporaryFile: Hashable {
 
 let projectName = "Project Name"
 let serviceURL = URL(string: "https://example.com/v1/metrics")!
+let additionalHeaders = ["key": "value"]
 
 class MetricsUploaderLogicTests: XCTestCase {
 
@@ -45,6 +46,7 @@ class MetricsUploaderLogicTests: XCTestCase {
     private let initial = MetricsUploaderModel(buildDirectory: "BUILD_DIR",
                                                projectName: projectName,
                                                serviceURL: serviceURL,
+                                               additionalHeaders: additionalHeaders,
                                                timeout: 1,
                                                isCI: false,
                                                plugins: [])
@@ -81,6 +83,7 @@ class MetricsUploaderLogicTests: XCTestCase {
                 hasEffects([
                     .uploadLogs(
                         serviceURL: serviceURL,
+                        additionalHeaders: additionalHeaders,
                         projectName: projectName,
                         isCI: false,
                         logs: Set([MetricsUploadRequest(fileURL: cachedLog, request: UploadBuildMetricsRequest())])
@@ -107,6 +110,7 @@ class MetricsUploaderLogicTests: XCTestCase {
                     ),
                     .uploadLogs(
                         serviceURL: serviceURL,
+                        additionalHeaders: additionalHeaders,
                         projectName: projectName,
                         isCI: false,
                         logs: Set([

--- a/Tests/XCMetricsTests/XCMetricsUploaderArgumentTests.swift
+++ b/Tests/XCMetricsTests/XCMetricsUploaderArgumentTests.swift
@@ -47,7 +47,11 @@ class XCMetricsArgumentTests: XCTestCase {
             "--buildDir",
             "/Users/Username/Library/Developer/Xcode/DerivedData/test/",
             "--timeout",
-            "10"
+            "10",
+            "--authorizationKey",
+            "Authorization",
+            "--authorizationValue",
+            "Bearer XXXXXXXXXXXXXXX"
         ]))
 
         XCTAssertNoThrow(try XCMetrics.parse([
@@ -56,7 +60,11 @@ class XCMetricsArgumentTests: XCTestCase {
             "-b",
             "/Users/Username/Library/Developer/Xcode/DerivedData/test/",
             "-t",
-            "10"
+            "10",
+            "-k",
+            "Authorization",
+            "-a",
+            "Bearer XXXXXXXXXXXXXXX"
         ]))
     }
 

--- a/docs/Getting Started.md
+++ b/docs/Getting Started.md
@@ -48,7 +48,10 @@ This is how the post-action scheme should look like. Let's break it down:
 	- `--serviceURL`: the URL of the service receiving the collected metrics. If you haven't deployed a service yet, please head over to ["Deploy Backend"](https://github.com/spotify/XCMetrics/blob/main/docs/How%20to%20Deploy%20Backend.md) first.
     - `--timeout`: the number of seconds to wait for the Xcode log to appear. The default value is 5s.
     - `--isCI`: either true or false based on if the current build is running on CI or not. This is useful to categorize builds as local or continuous integration builds.
-    - `--skipNotes`: true or false. If true, the Notes found in a log (Xcode adds them to with things like the output of Post build phase's scripts like Swiftlint) won't be inserted in the Database. Useful if you have thousands of these in your log and want to save some space. 
+    - `--skipNotes`: true or false. If true, the Notes found in a log (Xcode adds them to with things like the output of Post build phase's scripts like Swiftlint) won't be inserted in the Database. Useful if you have thousands of these in your log and want to save some space.
+    - `--authorizationKey`: An optional authorization header **key** to be included in the upload request e.g 'Authorization' or 'x-api-key' etc. This is ignored by the XCMetrics backend service, but can be consumed by a 3rd party service to facilitate a basic level of authentication. An example of this would be using an AWS API Gateway API Key. **Must** be used in conjunction with `authorizationValue`.
+    - `--authorizationValue`: An optional authorization header **value** to be included in the upload request e.g 'Basic YWxhZGRpbjpvcGVuc2VzYW1l' or `hYDqG78OIUDIWKLdwjdwhdu8` etc. This is ignored by the XCMetrics backend service, but can be consumed by a 3rd party service to facilitate a basic level of authentication. An example of this would be using an AWS API Gateway API Key. **Must** be used in conjunction with `authorizationKey`.
+    
 
 ![](img/post-action-scheme.png)
 


### PR DESCRIPTION
# Overview

We are currently using AWS to host the XCMetrics backend and want to lock down the API so it can only be used for developers within our team. To close down the API somewhat we decided to use the functionality within API Gateway to provide a basic level of authentication.

For this to work we need to send additional headers with the `xcactivitylog ` upload requests. This is something that the XCMetrics client doesn't yet support. This PR adds support for two additional flags; `authorizationKey` and `authorizationValue`. The reason for allowing the key to be configurable was down to making this functionality as flexible as possible. Whilst a lot of cases you may use the standard `Authorisation` key, there are instances where you may just wish to use an API token with a custom key e.g `x-api-key`.

# Details

Two additional flags have been added:

- `--authorizationKey`: An optional authorization header **key** to be included in the upload request e.g 'Authorization' or 'x-api-key' etc. This is ignored by the XCMetrics backend service, but can be consumed by a 3rd party service to facilitate a basic level of authentication. An example of this would be using an AWS API Gateway API Key. **Must** be used in conjunction with `authorizationValue`.
- `--authorizationValue`: An optional authorization header **value** to be included in the upload request e.g 'Basic YWxhZGRpbjpvcGVuc2VzYW1l' or `hYDqG78OIUDIWKLdwjdwhdu8` etc. This is ignored by the XCMetrics backend service, but can be consumed by a 3rd party service to facilitate a basic level of authentication. An example of this would be using an AWS API Gateway API Key. **Must** be used in conjunction with `authorizationKey`.

Internally, the changes allow for any number of additional headers to be included within the `PUT` request which uploads the `xcactivitylog`. These headers are added prior to any required headers in the request builder so they can't be used to override required headers by XCMetrics.