### PR TITLE
Always emit `logsUploadFailed` event

### DIFF
--- a/Sources/XCMetricsClient/Mobius/Effect Handlers/UploadMetricsEffectHandler.swift
+++ b/Sources/XCMetricsClient/Mobius/Effect Handlers/UploadMetricsEffectHandler.swift
@@ -38,16 +38,12 @@ struct UploadMetricsEffectHandler: EffectHandler {
             projectName: effectParameters.projectName,
             isCI: effectParameters.isCI,
             skipNotes: effectParameters.skipNotes,
-            uploadRequests: effectParameters.logs) { successfulURLs, failedURLs in
-            var effects = [MetricsUploaderEvent]()
-            // Handle failed log uploads. Skip if empty.
-            if !failedURLs.isEmpty {
-                effects.append(.logsUploadFailed(logs: failedURLs))
-            }
-            // Handle successful log uploads.
-            effects.append(.logsUploaded(logs: successfulURLs))
-
-            callback.end(with: effects)
+            uploadRequests: effectParameters.logs
+        ) { successfulURLs, failedURLs in
+            callback.end(with: [
+                .logsUploadFailed(logs: failedURLs),
+                .logsUploaded(logs: successfulURLs)
+            ])
         }
         return AnonymousDisposable {}
     }


### PR DESCRIPTION
Fixes a bug where `MetricsUploaderLogic` never ended because it was
waiting for `savedUploadRequests` which never came as it is triggered
only as result of `logsUploadFailed` event.

`logsUploadFailed` event is now always emitted and it is responsibility
of handler to check if there was any actual failures from the payload.