### PR TITLE
Bug fixes

### DIFF
--- a/Sources/XCMetricsBackendLib/Common/Utils/Double+Utils.swift
+++ b/Sources/XCMetricsBackendLib/Common/Utils/Double+Utils.swift
@@ -24,7 +24,8 @@ extension Double {
     /// from https://stackoverflow.com/a/38036978
     func xcm_roundToDecimal(_ fractionDigits: Int) -> Double {
         let multiplier = pow(10, Double(fractionDigits))
-        return (self * 1000).rounded(.toNearestOrEven) / multiplier
+        return = (self * multiplier).rounded(.toNearestOrEven) / multiplier
+        return rounded
     }
 
 }

--- a/Sources/XCMetricsBackendLib/Common/Utils/Double+Utils.swift
+++ b/Sources/XCMetricsBackendLib/Common/Utils/Double+Utils.swift
@@ -24,8 +24,7 @@ extension Double {
     /// from https://stackoverflow.com/a/38036978
     func xcm_roundToDecimal(_ fractionDigits: Int) -> Double {
         let multiplier = pow(10, Double(fractionDigits))
-        return = (self * multiplier).rounded(.toNearestOrEven) / multiplier
-        return rounded
+        return (self * multiplier).rounded(.toNearestOrEven) / multiplier
     }
 
 }

--- a/tools/format-docs/Gemfile
+++ b/tools/format-docs/Gemfile
@@ -1,2 +1,2 @@
 source 'https://rubygems.org'
-gem 'nokogiri'
+gem "nokogiri", ">= 1.11.4"

--- a/tools/format-docs/Gemfile.lock
+++ b/tools/format-docs/Gemfile.lock
@@ -1,8 +1,8 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    mini_portile2 (2.5.0)
-    nokogiri (1.11.1)
+    mini_portile2 (2.5.3)
+    nokogiri (1.11.6)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
     racc (1.5.2)
@@ -11,7 +11,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  nokogiri
+  nokogiri (>= 1.11.4)
 
 BUNDLED WITH
    2.1.4


### PR DESCRIPTION
1. Fixes a bug rounding `durations` to 9 decimals
2. Bumps `nokogiri` gem. According to dependabot the version we used has a vulnerability.

TODO: add an action to fix the `duration` on existing tables. 