### PR TITLE
Delete downloaded logs on error

### DIFF
--- a/Sources/XCMetricsBackendLib/UploadMetrics/Repository/LogFileRepository.swift
+++ b/Sources/XCMetricsBackendLib/UploadMetrics/Repository/LogFileRepository.swift
@@ -49,7 +49,9 @@ struct LocalLogFileRepository: LogFileRepository {
     }
 
     func get(logURL: URL) throws -> URL {
-        return logURL
+        let tmp = try TemporaryFile(creatingTempDirectoryForFilename: "\(UUID().uuidString).xcactivitylog")
+        try FileManager.default.copyItem(atPath: logURL.path, toPath: tmp.fileURL.path)
+        return tmp.fileURL
     }
 
 }


### PR DESCRIPTION
Fixes a bug reported in Slack by @dlbuckley. If the job failed, the logs were not being removed from the `tmp` directory.

