### PR TITLE
Bump XCLogParser and improved deletion of local logs

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -384,8 +384,8 @@
         "repositoryURL": "https://github.com/spotify/xclogparser",
         "state": {
           "branch": null,
-          "revision": "171247366dd1bcd9bf61f9699867b18282eea842",
-          "version": "0.2.27"
+          "revision": "e463154a481c2e8162dec482296aae852f474728",
+          "version": "0.2.28"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
         .library(name: "XCMetricsUtils", targets: ["XCMetricsUtils"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/spotify/xclogparser", from: "0.2.27"),
+        .package(url: "https://github.com/spotify/xclogparser", from: "0.2.28"),
         .package(url: "https://github.com/apple/swift-package-manager.git", .exact("0.3.0")),
         .package(url: "https://github.com/grpc/grpc-swift.git", .exact("1.0.0-alpha.9")),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.23.0"),

--- a/Sources/XCMetricsBackendLib/UploadMetrics/LogProcessing/MetricsProcessor.swift
+++ b/Sources/XCMetricsBackendLib/UploadMetrics/LogProcessing/MetricsProcessor.swift
@@ -4,14 +4,14 @@ import Vapor
 struct MetricsProcessor {
 
     static func process(metricsRequest: UploadMetricsRequest,
-                 logURL: URL,
+                 logFile: LogFile,
                  redactUserData: Bool) throws -> BuildMetrics {
         let machineName = redactUserData ? metricsRequest.extraInfo.machineName.md5() : metricsRequest.extraInfo.machineName
         let userId = redactUserData ? metricsRequest.extraInfo.user.md5() : metricsRequest.extraInfo.user
         let userIdSHA256 = metricsRequest.extraInfo.user.sha256()
         let isCI = metricsRequest.extraInfo.isCI
         return try LogParser.parseFromURL(
-            logURL,
+            logFile.localURL,
             machineName: machineName,
             projectName: metricsRequest.extraInfo.projectName,
             userId: userId,

--- a/Sources/XCMetricsBackendLib/UploadMetrics/Repository/LogFileGCSRepository.swift
+++ b/Sources/XCMetricsBackendLib/UploadMetrics/Repository/LogFileGCSRepository.swift
@@ -86,7 +86,7 @@ struct LogFileGCSRepository: LogFileRepository {
         return fileURL
     }
 
-    func get(logURL: URL) throws -> URL {
+    func get(logURL: URL) throws -> LogFile {
         logger.info("[LogFileGCSRepository] get \(logURL), bucket: \(bucketName), object: \(logURL.lastPathComponent)")
         let httpClient = HTTPClient(eventLoopGroupProvider: .shared(group))
         defer {
@@ -114,7 +114,7 @@ struct LogFileGCSRepository: LogFileRepository {
                 return groupEventLoop.makeFailedFuture(error)
             }
         }.wait()
-        return localURL
+        return LogFile(remoteURL: logURL, localURL: localURL)
     }
 
 }

--- a/Sources/XCMetricsBackendLib/UploadMetrics/Repository/LogFileRepository.swift
+++ b/Sources/XCMetricsBackendLib/UploadMetrics/Repository/LogFileRepository.swift
@@ -20,6 +20,12 @@
 import Foundation
 import Vapor
 
+struct LogFile {
+    var remoteURL: URL
+
+    var localURL: URL
+}
+
 /// Stores an .xcactivitylog that would be processed in a later stage
 protocol LogFileRepository {
 
@@ -31,7 +37,17 @@ protocol LogFileRepository {
     /// Fetches the log from the given URL
     /// - Parameter logURL: URL of the log to fetch
     /// - Returns: A local URL to the file
-    func get(logURL: URL) throws -> URL
+    func get(logURL: URL) throws -> LogFile
+
+    func delete(log: LogFile, wasProcessed: Bool) throws
+
+}
+
+extension LogFileRepository {
+
+    func delete(log: LogFile, wasProcessed: Bool) throws {
+        try FileManager.default.removeItem(at: log.localURL)
+    }
 
 }
 
@@ -48,10 +64,19 @@ struct LocalLogFileRepository: LogFileRepository {
         return tmp.fileURL
     }
 
-    func get(logURL: URL) throws -> URL {
+    func get(logURL: URL) throws -> LogFile {
         let tmp = try TemporaryFile(creatingTempDirectoryForFilename: "\(UUID().uuidString).xcactivitylog")
         try FileManager.default.copyItem(atPath: logURL.path, toPath: tmp.fileURL.path)
-        return tmp.fileURL
+        return LogFile(remoteURL: logURL, localURL: tmp.fileURL)
+    }
+
+    func delete(log: LogFile, wasProcessed: Bool) throws {
+        try FileManager.default.removeItem(at: log.localURL)
+
+        // Always remove local files
+        if wasProcessed {
+            try FileManager.default.removeItem(at: log.remoteURL)
+        }
     }
 
 }

--- a/Sources/XCMetricsBackendLib/UploadMetrics/Repository/LogFileS3Repository.swift
+++ b/Sources/XCMetricsBackendLib/UploadMetrics/Repository/LogFileS3Repository.swift
@@ -64,7 +64,7 @@ struct LogFileS3Repository: LogFileRepository {
         return url
     }
 
-    func get(logURL: URL) throws -> URL {
+    func get(logURL: URL) throws -> LogFile {
         guard let bucket = logURL.host else {
             throw RepositoryError.unexpected(message: "URL is not an S3 url \(logURL)")
         }
@@ -79,7 +79,7 @@ struct LogFileS3Repository: LogFileRepository {
         }
         let tmp = try TemporaryFile(creatingTempDirectoryForFilename: "\(UUID().uuidString).xcactivitylog")
         try data.write(to: tmp.fileURL)
-        return tmp.fileURL
+        return LogFile(remoteURL: logURL, localURL: tmp.fileURL)
     }
 
 }


### PR DESCRIPTION
1. Bump XCLogParser to latest version
2. Improved local file deletion. There was a case where successful processed logs were not being deleted.