### PR TITLE
Daily build time statistics

### DIFF
--- a/Sources/XCMetricsBackendLib/Config/configure.swift
+++ b/Sources/XCMetricsBackendLib/Config/configure.swift
@@ -92,7 +92,8 @@ public func configure(_ app: Application) throws {
                        AddTargetIdentifierIndexToSteps(),
                        AddStepIdentifierIndexToSwiftFunctions(),
                        AddStepIdentifierIndexToSwiftTypeChecks(),
-                       CreateDayCount()
+                       CreateDayCount(),
+                       CreateDayBuildTime()
                        )
 
 

--- a/Sources/XCMetricsBackendLib/Statistics/Controllers/StatisticsController.swift
+++ b/Sources/XCMetricsBackendLib/Statistics/Controllers/StatisticsController.swift
@@ -104,7 +104,9 @@ public struct StatisticsController: RouteCollection {
 
     /// Endpoint that returns a list of `DayBuildTime` which includes
     /// the build times for a number of procentiles of the builds and the total
-    /// build time for each day, in seconds
+    /// build time for each day, in seconds.
+    /// The `durationPX` fields indicate that X % of the builds of the a day
+    /// had a duration less or equal to the value.
     /// - Method: `GET`
     /// - Route: `/v1/statistics/build/time?days=14`
     /// - Request parameters

--- a/Sources/XCMetricsBackendLib/Statistics/Jobs/DailyStatisticsJob.swift
+++ b/Sources/XCMetricsBackendLib/Statistics/Jobs/DailyStatisticsJob.swift
@@ -33,5 +33,7 @@ struct DailyStatisticsJob: ScheduledJob {
     func run(context: QueueContext) -> EventLoopFuture<Void> {
         let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: Date())!
         return repository.createDayCount(day: yesterday, using: context.eventLoop)
+            .and(repository.createDayBuildTime(day: yesterday, using: context.eventLoop))
+            .transform(to: context.eventLoop.makeSucceededFuture(()))
     }
 }

--- a/Sources/XCMetricsBackendLib/Statistics/Model/DayBuildTime.swift
+++ b/Sources/XCMetricsBackendLib/Statistics/Model/DayBuildTime.swift
@@ -27,8 +27,10 @@ public final class DayBuildTime: DayData {
     @ID(custom: "day")
     public var id: Date?;
 
+    // Fields with suffix PX represent X-th percentiles
+
     @Field(key: "duration_p50")
-    var durationP50: Double
+    var durationP50: Double;
 
     @Field(key: "duration_p95")
     var durationP95: Double;

--- a/Sources/XCMetricsBackendLib/Statistics/Model/DayBuildTime.swift
+++ b/Sources/XCMetricsBackendLib/Statistics/Model/DayBuildTime.swift
@@ -20,7 +20,7 @@
 import Vapor
 import Fluent
 
-public final class DayBuildTime: Model, Content {
+public final class DayBuildTime: DayData {
 
     public static let schema = "statistics_day_build_time";
 

--- a/Sources/XCMetricsBackendLib/Statistics/Model/DayBuildTime.swift
+++ b/Sources/XCMetricsBackendLib/Statistics/Model/DayBuildTime.swift
@@ -1,0 +1,58 @@
+// Copyright (c) 2021 Spotify AB.
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import Vapor
+import Fluent
+
+public final class DayBuildTime: Model, Content {
+
+    public static let schema = "statistics_day_build_time";
+
+    @ID(custom: "day")
+    public var id: Date?;
+
+    @Field(key: "duration_p50")
+    var durationP50: Double
+
+    @Field(key: "duration_p95")
+    var durationP95: Double;
+
+    @Field(key: "total_duration")
+    var totalDuration: Double;
+
+    public convenience init() {
+        self.init(day: Date().xcm_truncateTime())
+    }
+
+    public convenience init(day: Date) {
+        self.init(day: day, durationP50: 0, durationP95: 0, totalDuration: 0)
+    }
+
+    init(
+        day: Date,
+        durationP50: Double = 0,
+        durationP95: Double = 0,
+        totalDuration: Double = 0
+    ) {
+        self.id = day;
+        self.durationP50 = durationP50;
+        self.durationP95 = durationP95;
+        self.totalDuration = totalDuration;
+    }
+}

--- a/Sources/XCMetricsBackendLib/Statistics/Model/DayData.swift
+++ b/Sources/XCMetricsBackendLib/Statistics/Model/DayData.swift
@@ -20,30 +20,9 @@
 import Vapor
 import Fluent
 
-public final class DayCount: DayData {
+public protocol DayData: Model, Content {
 
-    public static let schema = "statistics_day_counts";
+    var id: Date? { get set }
 
-    @ID(custom: "day")
-    public var id: Date?;
-
-    @Field(key: "build_count")
-    var builds: Int;
-
-    @Field(key: "error_count")
-    var errors: Int;
-
-    public convenience init() {
-        self.init(day: Date().xcm_truncateTime())
-    }
-
-    public convenience init(day: Date) {
-        self.init(day: day, builds: 0, errors: 0)
-    }
-
-    init(day: Date, builds: Int = 0, errors: Int = 0) {
-        self.id = day;
-        self.builds = builds;
-        self.errors = errors;
-    }
+    init(day: Date)
 }

--- a/Sources/XCMetricsBackendLib/Statistics/Repositories/Migrations/CreateDayBuildTime.swift
+++ b/Sources/XCMetricsBackendLib/Statistics/Repositories/Migrations/CreateDayBuildTime.swift
@@ -1,0 +1,36 @@
+// Copyright (c) 2021 Spotify AB.
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import Fluent
+
+struct CreateDayBuildTime: Migration {
+    // Adds fields for build times to DayCount model
+    func prepare(on database: Database) -> EventLoopFuture<Void> {
+        database.schema(DayBuildTime.schema)
+            .field("day", .date, .identifier(auto: false))
+            .field("duration_p50", .double, .required)
+            .field("duration_p95", .double, .required)
+            .field("total_duration", .double, .required)
+            .create()
+    }
+
+    func revert(on database: Database) -> EventLoopFuture<Void> {
+        return database.schema(DayBuildTime.schema).delete()
+    }
+}

--- a/Sources/XCMetricsBackendLib/Statistics/Repositories/Migrations/CreateDayBuildTime.swift
+++ b/Sources/XCMetricsBackendLib/Statistics/Repositories/Migrations/CreateDayBuildTime.swift
@@ -20,7 +20,7 @@
 import Fluent
 
 struct CreateDayBuildTime: Migration {
-    // Adds fields for build times to DayCount model
+    // Adds a relation for DayBuildTime models
     func prepare(on database: Database) -> EventLoopFuture<Void> {
         database.schema(DayBuildTime.schema)
             .field("day", .date, .identifier(auto: false))

--- a/Sources/XCMetricsBackendLib/Statistics/Repositories/SQLStatisticsRepository.swift
+++ b/Sources/XCMetricsBackendLib/Statistics/Repositories/SQLStatisticsRepository.swift
@@ -119,6 +119,7 @@ class SQLStatisticsRepository: StatisticsRepository {
                     )
                 }
 
+                // Nearest-rank percentiles
                 let durationP50 = durations[Int((0.50 * count).rounded(.up)) - 1]
                 let durationP95 = durations[Int((0.95 * count).rounded(.up)) - 1]
                 let totalDuration = durations.reduce(0, +)

--- a/Sources/XCMetricsBackendLib/Statistics/Repositories/SQLStatisticsRepository.swift
+++ b/Sources/XCMetricsBackendLib/Statistics/Repositories/SQLStatisticsRepository.swift
@@ -52,7 +52,7 @@ class SQLStatisticsRepository: StatisticsRepository {
             .all()
             .flatMap { counts in
                 return eventLoop.makeSucceededFuture(
-                    self.fillDayCounts(counts: counts, from: from, to: to)
+                    self.fillDays(dayStatistics: counts, from: from, to: to)
                 )
             }
 
@@ -90,21 +90,21 @@ class SQLStatisticsRepository: StatisticsRepository {
     /// Since days without any build information potentially could exist (for instance if a job has failed or not been run)
     /// we need to fill days without build information with zero values to keep the format consistent.
     /// Performance of this method should be considered for large date ranges.
-    private func fillDayCounts(counts: [DayCount], from: Date, to: Date) -> [DayCount] {
+    private func fillDays<T: DayData>(dayStatistics: [T], from: Date, to: Date) -> [T] {
         let from = from.xcm_truncateTime()
         let days = Calendar.current.dateComponents([.day], from: from, to: to.xcm_truncateTime()).day! + 1
 
-        guard days > 0 && counts.count != days else { return counts }
+        guard days > 0 && dayStatistics.count != days else { return dayStatistics }
 
-        var filled = [DayCount]()
+        var filled = [T]()
 
         for dayOffset in 0..<days {
             let day = Calendar.current.date(byAdding: .day, value: dayOffset, to: from)!
 
-            if let dayCount = counts.first(where: { $0.id == day }) {
-                filled.append(dayCount)
+            if let dayStatistic = dayStatistics.first(where: { $0.id == day }) {
+                filled.append(dayStatistic)
             } else {
-                filled.append(DayCount(day: day))
+                filled.append(T(day: day))
             }
         }
 

--- a/Sources/XCMetricsBackendLib/Statistics/Repositories/StatisticsRepository.swift
+++ b/Sources/XCMetricsBackendLib/Statistics/Repositories/StatisticsRepository.swift
@@ -48,4 +48,24 @@ public protocol StatisticsRepository {
     ///   - day: Date to calculate
     ///   - eventLoop: Eventloop to use
     func createDayCount(day: Date, using eventLoop: EventLoop) -> EventLoopFuture<Void>
+
+    /// Fetches build times for a date range, sorted by date
+    /// - Parameters:
+    ///   - from: Start of date range, inclusive.
+    ///   - to: End of date range, inclusive.
+    ///   - eventLoop: Eventloop to use
+    func getDayBuildTimes(from: Date, to: Date, using eventLoop: EventLoop) -> EventLoopFuture<[DayBuildTime]>
+
+    /// Calculates and returns build time information for a given day
+    /// - Parameters:
+    ///   - day: Date to calculate
+    ///   - eventLoop: Eventloop to use
+    func getBuildTime(day: Date, using eventLoop: EventLoop) -> EventLoopFuture<DayBuildTime>
+
+    /// Calculates and stores build time information for a given day
+    /// - Parameters:
+    ///   - day: Date to calculate
+    ///   - eventLoop: Eventloop to use
+    func createDayBuildTime(day: Date, using eventLoop: EventLoop) -> EventLoopFuture<Void>
+
 }

--- a/Tests/XCMetricsBackendLibTests/StatisticsTests/DailyStatisticsJobTests.swift
+++ b/Tests/XCMetricsBackendLibTests/StatisticsTests/DailyStatisticsJobTests.swift
@@ -34,11 +34,19 @@ final class DailyStatisticsJobTests: XCTestCase {
         )
         
         let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: Date())!
+
         let dayCounts = try repository.getDayCounts(
             from: yesterday, to: yesterday, using: app.queues.queue.context.eventLoop
         ).wait()
 
         XCTAssertEqual(dayCounts.count, 1)
         XCTAssertEqual(dayCounts.first!.id, yesterday.xcm_truncateTime())
+
+        let dayBuildTimes = try repository.getDayBuildTimes(
+            from: yesterday, to: yesterday, using: app.queues.queue.context.eventLoop
+        ).wait()
+
+        XCTAssertEqual(dayBuildTimes.count, 1)
+        XCTAssertEqual(dayBuildTimes.first!.id, yesterday.xcm_truncateTime())
     }
 }


### PR DESCRIPTION
- New `DayBuildTime` model that is ment to be created each day by the `DailyStatisticsJobs`
- Endpoint and repository functionality to store and retrieve time data of builds.