### PR TITLE
fix: Docker image version

### DIFF
--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -13,7 +13,7 @@ services:
       retries: 5
 
   postgresql:
-    image: postgres
+    image: postgres:12
     ports:
       - "5432:5432"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - "6379:6379"
 
   postgresql:
-    image: postgres
+    image: postgres:12
     container_name: pg-xcmetrics
     ports:
       - "5432:5432"


### PR DESCRIPTION
When using postgres latest image (version 14),
the swift library can't connect to postgres.
Because of that we have to use fixed postgres image version.
Signed-off-by: Kaan Karakaya <yusufkaan142@gmail.com>