### PR TITLE
XCMetrics: Fix compilation for Xcode 13 beta 4 and above.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -344,21 +344,21 @@
         }
       },
       {
-        "package": "SwiftPM",
-        "repositoryURL": "https://github.com/apple/swift-package-manager.git",
-        "state": {
-          "branch": null,
-          "revision": "235aacc514cb81a6881364b0fedcb3dd083228f3",
-          "version": "0.3.0"
-        }
-      },
-      {
         "package": "SwiftProtobuf",
         "repositoryURL": "https://github.com/apple/swift-protobuf.git",
         "state": {
           "branch": null,
           "revision": "0279688c9fc5a40028e1b5bb0cb56534a45a6020",
           "version": "1.12.0"
+        }
+      },
+      {
+        "package": "swift-tools-support-core",
+        "repositoryURL": "https://github.com/apple/swift-tools-support-core.git",
+        "state": {
+          "branch": null,
+          "revision": "3b6b97d612b56e25d80d0807f5bc38ea08b7bdf3",
+          "version": "0.2.3"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/spotify/xclogparser", from: "0.2.28"),
-        .package(url: "https://github.com/apple/swift-package-manager.git", .exact("0.3.0")),
+        .package(url: "https://github.com/apple/swift-tools-support-core.git", .exact("0.2.3")),
         .package(url: "https://github.com/grpc/grpc-swift.git", .exact("1.0.0-alpha.9")),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.23.0"),
         .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.15.0"),
@@ -95,7 +95,7 @@ let package = Package(
         .target(name: "XCMetricsBackend", dependencies: [.target(name: "XCMetricsBackendLib")]),
         .testTarget(
             name: "XCMetricsTests",
-            dependencies: ["XCMetricsClient", "XCMetricsProto", "MobiusTest", .product(name: "Utility", package: "SwiftPM")]
+            dependencies: ["XCMetricsClient", "XCMetricsProto", "MobiusTest", "SwiftToolsSupport"]
         ),
         .testTarget(
             name: "XCMetricsPluginsTests",

--- a/Tests/XCMetricsTests/Effect Handlers/CacheLogsEffectHandlerTests.swift
+++ b/Tests/XCMetricsTests/Effect Handlers/CacheLogsEffectHandlerTests.swift
@@ -17,12 +17,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import Basic
 import MobiusCore
 import MobiusTest
-import Utility
 import XCLogParser
 import XCTest
+import TSCBasic
+import TSCUtility
 @testable import XCMetricsClient
 
 final class CacheLogsEffectHandlerTests: XCTestCase {
@@ -31,37 +31,37 @@ final class CacheLogsEffectHandlerTests: XCTestCase {
 
         var xcodeLogsURL: Set<URL> {
             return Set(xcodeLogs.map {
-                URL(fileURLWithPath: $0.path.asString)
+                URL(fileURLWithPath: $0.path.pathString)
             })
         }
 
         var cachedLogsURL: Set<URL> {
             return Set(cachedLogs.map {
-                URL(fileURLWithPath: $0.path.asString)
+                URL(fileURLWithPath: $0.path.pathString)
             })
         }
 
         var newlyCachedLogsURL: Set<URL> {
             return Set(newlyCachedLogs.map {
-                URL(fileURLWithPath: $0.path.asString)
+                URL(fileURLWithPath: $0.path.pathString)
             })
         }
 
         private let xcodeLogs = Set(arrayLiteral:
-            try! TemporaryFile(prefix: "log1", suffix: ".xcactivitylog"),
-            try! TemporaryFile(prefix: "log2", suffix: ".xcactivitylog"),
-            try! TemporaryFile(prefix: "log3", suffix: ".xcactivitylog"),
-            try! TemporaryFile(prefix: "log4", suffix: ".xcactivitylog")
+            try! TemporaryFile.newFile(prefix: "log1", suffix: ".xcactivitylog"),
+            try! TemporaryFile.newFile(prefix: "log2", suffix: ".xcactivitylog"),
+            try! TemporaryFile.newFile(prefix: "log3", suffix: ".xcactivitylog"),
+            try! TemporaryFile.newFile(prefix: "log4", suffix: ".xcactivitylog")
         )
 
         private let cachedLogs = Set(arrayLiteral:
-            try! TemporaryFile(prefix: "log10", suffix: ".xcactivitylog"),
-            try! TemporaryFile(prefix: "log20", suffix: ".xcactivitylog"),
-            try! TemporaryFile(prefix: "log30", suffix: ".xcactivitylog")
+            try! TemporaryFile.newFile(prefix: "log10", suffix: ".xcactivitylog"),
+            try! TemporaryFile.newFile(prefix: "log20", suffix: ".xcactivitylog"),
+            try! TemporaryFile.newFile(prefix: "log30", suffix: ".xcactivitylog")
         )
 
         private let newlyCachedLogs = Set(arrayLiteral:
-            try! TemporaryFile(prefix: "log100", suffix: ".xcactivitylog")
+            try! TemporaryFile.newFile(prefix: "log100", suffix: ".xcactivitylog")
         )
 
         func retrieveXcodeLogs(in buildDirectory: String, timeout: Int) throws -> (currentLog: URL?, otherLogs: Set<URL>) {
@@ -145,7 +145,7 @@ final class CacheLogsEffectHandlerTests: XCTestCase {
     }
 
     func testCacheLogsCachesCurrentLog() {
-        let currentLogURL = try! TemporaryFile(prefix: "log1", suffix: ".xcactivitylog").url
+        let currentLogURL = try! TemporaryFile.newFile(prefix: "log1", suffix: ".xcactivitylog").url
         var receivedEvent: MetricsUploaderEvent?
         send = { receivedEvent = $0 }
 
@@ -161,7 +161,7 @@ final class CacheLogsEffectHandlerTests: XCTestCase {
     }
 
     func testCacheLogsReportsNotAlreadyCachedLog() {
-        let alreadyCachedLogURL = try! TemporaryFile(prefix: "log1", suffix: ".xcactivitylog").url
+        let alreadyCachedLogURL = try! TemporaryFile.newFile(prefix: "log1", suffix: ".xcactivitylog").url
         let uploadRequestFileURL = alreadyCachedLogURL
             .deletingLastPathComponent()
             .appendingPathComponent(LogManagerImplementation.failedRequestsDirectoryName)

--- a/Tests/XCMetricsTests/Effect Handlers/LogsCleanUpEffectHandlerTests.swift
+++ b/Tests/XCMetricsTests/Effect Handlers/LogsCleanUpEffectHandlerTests.swift
@@ -17,10 +17,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import Basic
 import MobiusCore
 import MobiusTest
-import Utility
+import TSCBasic
+import TSCUtility
 import XCTest
 @testable import XCMetricsClient
 
@@ -30,14 +30,14 @@ final class UploadedLogTaggerEffectHandlerTests: XCTestCase {
 
         var evictedLogsURL: Set<URL> {
             return Set(evictedLogs.map {
-                URL(fileURLWithPath: $0.path.asString)
+                URL(fileURLWithPath: $0.path.pathString)
             })
         }
 
         private let evictedLogs = Set(arrayLiteral:
-            try! TemporaryFile(prefix: "log10", suffix: ".xcactivitylog"),
-            try! TemporaryFile(prefix: "log20", suffix: ".xcactivitylog"),
-            try! TemporaryFile(prefix: "log30", suffix: ".xcactivitylog")
+            try! TemporaryFile.newFile(prefix: "log10", suffix: ".xcactivitylog"),
+            try! TemporaryFile.newFile(prefix: "log20", suffix: ".xcactivitylog"),
+            try! TemporaryFile.newFile(prefix: "log30", suffix: ".xcactivitylog")
         )
 
         func retrieveXcodeLogs(in buildDirectory: String, timeout: Int) throws -> (currentLog: URL?, otherLogs: Set<URL>) {

--- a/Tests/XCMetricsTests/Effect Handlers/LogsFinderEffectHandlerTests.swift
+++ b/Tests/XCMetricsTests/Effect Handlers/LogsFinderEffectHandlerTests.swift
@@ -17,9 +17,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import Basic
 import MobiusCore
-import Utility
+import TSCBasic
+import TSCUtility
 import XCTest
 @testable import XCMetricsClient
 
@@ -30,33 +30,33 @@ final class LogsFinderEffectHandlerTests: XCTestCase {
     struct MockLogManager: LogManager {
         var xcodeLogsURL: Set<URL> {
             return Set(xcodeLogs.map {
-                URL(fileURLWithPath: $0.path.asString)
+                URL(fileURLWithPath: $0.path.pathString)
             })
         }
 
         var lastXcodeLogURL: URL? {
-            return URL(fileURLWithPath: lastXcodeLog.path.asString)
+            return URL(fileURLWithPath: lastXcodeLog.path.pathString)
         }
 
         var cachedLogsURL: Set<URL> {
             return Set(cachedLogs.map {
-                URL(fileURLWithPath: $0.path.asString)
+                URL(fileURLWithPath: $0.path.pathString)
             })
         }
 
         private let xcodeLogs = Set(arrayLiteral:
-            try! TemporaryFile(prefix: "log1", suffix: ".xcactivitylog"),
-            try! TemporaryFile(prefix: "log2", suffix: ".xcactivitylog"),
-            try! TemporaryFile(prefix: "log3", suffix: ".xcactivitylog"),
-            try! TemporaryFile(prefix: "log4", suffix: ".xcactivitylog")
+            try! TemporaryFile.newFile(prefix: "log1", suffix: ".xcactivitylog"),
+            try! TemporaryFile.newFile(prefix: "log2", suffix: ".xcactivitylog"),
+            try! TemporaryFile.newFile(prefix: "log3", suffix: ".xcactivitylog"),
+            try! TemporaryFile.newFile(prefix: "log4", suffix: ".xcactivitylog")
         )
 
-        private var lastXcodeLog = try! TemporaryFile(prefix: "log5", suffix: ".xcactivitylog")
+        private var lastXcodeLog = try! TemporaryFile.newFile(prefix: "log5", suffix: ".xcactivitylog")
 
         private let cachedLogs = Set(arrayLiteral:
-            try! TemporaryFile(prefix: "log10", suffix: ".xcactivitylog"),
-            try! TemporaryFile(prefix: "log20", suffix: ".xcactivitylog"),
-            try! TemporaryFile(prefix: "log30", suffix: ".xcactivitylog")
+            try! TemporaryFile.newFile(prefix: "log10", suffix: ".xcactivitylog"),
+            try! TemporaryFile.newFile(prefix: "log20", suffix: ".xcactivitylog"),
+            try! TemporaryFile.newFile(prefix: "log30", suffix: ".xcactivitylog")
         )
 
         func retrieveXcodeLogs(in buildDirectory: String, timeout: Int) throws -> (currentLog: URL?, otherLogs: Set<URL>) {

--- a/Tests/XCMetricsTests/Effect Handlers/LogsTaggerEffectHandlerTests.swift
+++ b/Tests/XCMetricsTests/Effect Handlers/LogsTaggerEffectHandlerTests.swift
@@ -17,10 +17,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import Basic
 import MobiusCore
 import MobiusTest
-import Utility
+import TSCBasic
+import TSCUtility
 import XCTest
 @testable import XCMetricsClient
 
@@ -84,8 +84,8 @@ final class LogsTaggerEffectHandlerTests: XCTestCase {
         super.setUp()
 
         uploadedLogs = [
-            try! TemporaryFile(prefix: UUID().uuidString, suffix: ".xcactivitylog"),
-            try! TemporaryFile(prefix: UUID().uuidString, suffix: ".xcactivitylog")
+            try! TemporaryFile.newFile(prefix: UUID().uuidString, suffix: ".xcactivitylog"),
+            try! TemporaryFile.newFile(prefix: UUID().uuidString, suffix: ".xcactivitylog")
         ]
 
         uploadedTaggedLogs = [

--- a/Tests/XCMetricsTests/Effect Handlers/UploadMetricsEffectHandlerTests.swift
+++ b/Tests/XCMetricsTests/Effect Handlers/UploadMetricsEffectHandlerTests.swift
@@ -17,9 +17,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import Basic
+//import Basic
 import MobiusCore
-import Utility
+//import Utility
 import XCTest
 @testable import XCMetricsClient
 

--- a/Tests/XCMetricsTests/LogManagerImplementationTests.swift
+++ b/Tests/XCMetricsTests/LogManagerImplementationTests.swift
@@ -18,8 +18,8 @@
 // under the License.
 
 import XCTest
-import Basic
-import Utility
+import TSCBasic
+import TSCUtility
 @testable import XCMetricsClient
 
 class LogManagerImplementationTests: XCTestCase {
@@ -341,8 +341,8 @@ class LogManagerImplementationTests: XCTestCase {
     }
 
     func testLogsToUploadRetrieval() throws {
-        let log1 = try! TemporaryFile(prefix: "log1", suffix: ".xcactivitylog")
-        let log2 = try! TemporaryFile(prefix: "log2", suffix: ".xcactivitylog")
+        let log1 = try! TemporaryFile.newFile(prefix: "log1", suffix: ".xcactivitylog")
+        let log2 = try! TemporaryFile.newFile(prefix: "log2", suffix: ".xcactivitylog")
         let log1UploadRequestURL = writeUploadBuildMetricsRequest(at: log1.url)
         let log2UploadRequestURL = writeUploadBuildMetricsRequest(at: log2.url)
         mockFileAccessor.entriesOfDirectoryToReturn = [

--- a/Tests/XCMetricsTests/MetricsUploaderLogicTests.swift
+++ b/Tests/XCMetricsTests/MetricsUploaderLogicTests.swift
@@ -17,10 +17,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import Basic
 import MobiusCore
 import MobiusTest
-import Utility
+import TSCBasic
+import TSCUtility
 import XCTest
 @testable import XCMetricsClient
 
@@ -61,9 +61,9 @@ class MetricsUploaderLogicTests: XCTestCase {
     }
 
     func testFindLogs() {
-        let currentLog = try! TemporaryFile(prefix: "log5", suffix: ".xcactivitylog").url
-        let xcodeLog = try! TemporaryFile(prefix: "log1", suffix: ".xcactivitylog").url
-        let cacheLog = try! TemporaryFile(prefix: "log10", suffix: ".xcactivitylog").url
+        let currentLog = try! TemporaryFile.newFile(prefix: "log5", suffix: ".xcactivitylog").url
+        let xcodeLog = try! TemporaryFile.newFile(prefix: "log1", suffix: ".xcactivitylog").url
+        let cacheLog = try! TemporaryFile.newFile(prefix: "log10", suffix: ".xcactivitylog").url
 
         let xcodeLogs = Set(arrayLiteral: xcodeLog)
         let cacheLogs = Set(arrayLiteral: cacheLog)
@@ -75,7 +75,7 @@ class MetricsUploaderLogicTests: XCTestCase {
     }
 
     func testCacheLogs() {
-        let cachedLog = try! TemporaryFile(prefix: "log15", suffix: ".xcactivitylog").url
+        let cachedLog = try! TemporaryFile.newFile(prefix: "log15", suffix: ".xcactivitylog").url
         let expectedModel = initial.withChanged(awaitingParsingLogResponses: 0)
         spec.given(initial)
             .when(.logsCached(currentLog: nil, previousLogs: Set(arrayLiteral: cachedLog), cachedUploadRequests: []))
@@ -96,8 +96,8 @@ class MetricsUploaderLogicTests: XCTestCase {
     }
 
     func testCacheLogsWithCurrentLog() {
-        let cachedCurrentLog = try! TemporaryFile(prefix: "log10", suffix: ".xcactivitylog").url
-        let cachedLog = try! TemporaryFile(prefix: "log15", suffix: ".xcactivitylog").url
+        let cachedCurrentLog = try! TemporaryFile.newFile(prefix: "log10", suffix: ".xcactivitylog").url
+        let cachedLog = try! TemporaryFile.newFile(prefix: "log15", suffix: ".xcactivitylog").url
 
         let expectedModel = initial.withChanged(awaitingParsingLogResponses: 0)
         spec.given(initial)
@@ -126,12 +126,12 @@ class MetricsUploaderLogicTests: XCTestCase {
     }
 
     func testCacheLogsWithCurrentLogAndReturnMaximumNumberOfLogs() {
-        let cachedCurrentLog = try! TemporaryFile(prefix: "log10", suffix: ".xcactivitylog").url
+        let cachedCurrentLog = try! TemporaryFile.newFile(prefix: "log10", suffix: ".xcactivitylog").url
         let cachedLogs = Set([
-            try! TemporaryFile(prefix: "log15", suffix: ".xcactivitylog").url,
-            try! TemporaryFile(prefix: "log16", suffix: ".xcactivitylog").url,
-            try! TemporaryFile(prefix: "log17", suffix: ".xcactivitylog").url,
-            try! TemporaryFile(prefix: "log18", suffix: ".xcactivitylog").url,
+            try! TemporaryFile.newFile(prefix: "log15", suffix: ".xcactivitylog").url,
+            try! TemporaryFile.newFile(prefix: "log16", suffix: ".xcactivitylog").url,
+            try! TemporaryFile.newFile(prefix: "log17", suffix: ".xcactivitylog").url,
+            try! TemporaryFile.newFile(prefix: "log18", suffix: ".xcactivitylog").url,
         ])
         let uploadRequests = Set([
             try! MetricsUploadRequest(fileURL: URL(fileURLWithPath: "1"), request: UploadBuildMetricsRequest(jsonString: "{}")),
@@ -150,7 +150,7 @@ class MetricsUploaderLogicTests: XCTestCase {
 
     func testUploadLogs() {
         let uploadedLogs = Set(arrayLiteral:
-            try! TemporaryFile(prefix: "log10", suffix: ".xcactivitylog").url
+            try! TemporaryFile.newFile(prefix: "log10", suffix: ".xcactivitylog").url
         )
         spec.given(initial)
             .when(.logsUploaded(logs: uploadedLogs))
@@ -159,7 +159,7 @@ class MetricsUploaderLogicTests: XCTestCase {
 
     func testTagLogsAsUploaded() {
         let taggedLogs = Set(arrayLiteral:
-            try! TemporaryFile(prefix: "log10_UPLOADED", suffix: ".xcactivitylog").url
+            try! TemporaryFile.newFile(prefix: "log10_UPLOADED", suffix: ".xcactivitylog").url
         )
         spec.given(initial)
             .when(.logsTaggedAsUploaded(logs: taggedLogs))
@@ -170,7 +170,7 @@ class MetricsUploaderLogicTests: XCTestCase {
         // Make sure loop completes.
         expectation(forNotification: .mobiusLoopCompleted, object: nil, handler: nil)
         let cleanedUpLogs = Set(arrayLiteral:
-            try! TemporaryFile(prefix: "log10", suffix: ".xcactivitylog").url
+            try! TemporaryFile.newFile(prefix: "log10", suffix: ".xcactivitylog").url
         )
         spec.given(initial)
             .when(.cleanedUpLogs(logs: cleanedUpLogs), .savedUploadRequests)

--- a/Tests/XCMetricsTests/TemporaryFile+Utils.swift
+++ b/Tests/XCMetricsTests/TemporaryFile+Utils.swift
@@ -17,12 +17,16 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import Basic
-import Utility
+import TSCBasic
+import TSCUtility
 
 extension TemporaryFile {
 
     var url: URL {
-        return URL(fileURLWithPath: self.path.asString)
+        return URL(fileURLWithPath: self.path.pathString)
+    }
+
+    static func newFile(prefix: String, suffix: String) throws -> Self {
+        return try withTemporaryFile(dir: nil, prefix: prefix, suffix: suffix, deleteOnClose: false) { return $0 }
     }
 }


### PR DESCRIPTION
Swift Package Manager had a function called `await` that fails due to
the introduction of async/await in Swift.
XCMetrics uses functionality that now exists in [Swift Tools Core
Support](https://github.com/apple/swift-tools-support-core), so this
commit removes SPM from the package dependencies and adds the
aforementioned package instead.
In addition this commit fixes some API changes with regards to
`TemporaryFile` and `AbsolutePath`.

Inspired by the fix in [Xcparse](https://github.com/ChargePoint/xcparse/pull/63).