### PR TITLE
XCMetricsLauncher: Wrap XCMetrics path parameter with quotes.

### DIFF
--- a/XCMetricsLauncher
+++ b/XCMetricsLauncher
@@ -9,6 +9,6 @@
 # One of the side effects of not using this hack is to have "Build Succeeded"
 # notifications be delayed until the post-action scheme completes, thus we recommend
 # always launching XCMetrics through this script.
-executable=$1
+executable="$1"
 shift;
-$executable "$@" <&- >&- 2>&- &
+"$executable" "$@" <&- >&- 2>&- &


### PR DESCRIPTION
Previously, if the path contained whitespaces, the lanucher wouldn't run
the script at the given path.