### PR TITLE
XCMetricsClient: Create additional header with a stringified json

### DIFF
--- a/Sources/XCMetricsClient/Utils/AdditionalHeaderFactory.swift
+++ b/Sources/XCMetricsClient/Utils/AdditionalHeaderFactory.swift
@@ -1,0 +1,19 @@
+import Foundation
+import ArgumentParser
+
+final class AdditionalHeaderFactory {
+    static func make(authorizationKey: String?,
+                     authorizationValue: String?,
+                     additionalHeader: [String: String]) throws -> [String: String] {
+        switch (authorizationKey, authorizationValue) {
+        case let (.some(key), .some(value)):
+            var additionalHeader = additionalHeader
+            additionalHeader[key] = value
+            return additionalHeader
+        case (.none, .none):
+            return additionalHeader
+        case (.none, .some), (.some, .none):
+            throw ValidationError("The --authorizationKey must be used in conjunction with --authorizationValue. One cannot be used without the other.")
+        }
+    }
+}

--- a/Sources/XCMetricsClient/Utils/JSONArgument.swift
+++ b/Sources/XCMetricsClient/Utils/JSONArgument.swift
@@ -1,0 +1,14 @@
+import Foundation
+import ArgumentParser
+
+final class JSONArgument {
+    static func transformer(_ value: String) throws -> [String: String] {
+        guard let data = value.data(using: .utf8) else { throw ValidationError("Badly encoded string, should be UTF-8") }
+        let serializedData = try JSONSerialization.jsonObject(with: data, options: [])
+        guard let arguments = serializedData as? [String: Any] else {
+            throw ValidationError("Invalid json")
+        }
+        let mappedArguments = arguments.mapValues(String.init(describing:))
+        return mappedArguments
+    }
+}

--- a/docs/Getting Started.md
+++ b/docs/Getting Started.md
@@ -52,6 +52,7 @@ This is how the post-action scheme should look like. Let's break it down:
     - `--authorizationKey`: An optional authorization header **key** to be included in the upload request e.g 'Authorization' or 'x-api-key' etc. This is ignored by the XCMetrics backend service, but can be consumed by a 3rd party service to facilitate a basic level of authentication. An example of this would be using an AWS API Gateway API Key. **Must** be used in conjunction with `authorizationValue`.
     - `--authorizationValue`: An optional authorization header **value** to be included in the upload request e.g 'Basic YWxhZGRpbjpvcGVuc2VzYW1l' or `hYDqG78OIUDIWKLdwjdwhdu8` etc. This is ignored by the XCMetrics backend service, but can be consumed by a 3rd party service to facilitate a basic level of authentication. An example of this would be using an AWS API Gateway API Key. **Must** be used in conjunction with `authorizationKey`.
     - `--truncateLargeIssues`: Optional flag. If `true`, individual tasks with more than a 100 issues (either Warnings, Errors or Notes) will get their issues truncated to a 100. This is useful to save up database space, fix memory issues in the backend and speed up log processing.
+    - `--additionalHeaderJson`: Optinal flag. Wiht this, is possible to define aditional headers with a stringfied json. This option will be merged with `--authorizationKey` and `--authorizationValue` when they exists. Usage: `XCMetrics --additionalHeaderJson  '{"Api-Key":"123","Authorization":"bearer 456"}'`.
 
 
 ![](img/post-action-scheme.png)


### PR DESCRIPTION
This way we can use a json to pass multiple arguments to request header. For example:

```
XCMetrics \
    --name foo \
    --additionalHeaderJson  '{"Api-Key":"yYKZ8uDrMsjlXWKOaPbCh6bU30EST2cq","Authorization":"bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJYMlNtUWhudVh6LU52anR6VWlpNUZqM3V5VS1WR0hDeXdtUG5ocjBSQy1zIn0"}'
```