### PR TITLE
Bump XCLogParser

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -393,8 +393,8 @@
         "repositoryURL": "https://github.com/spotify/xclogparser",
         "state": {
           "branch": null,
-          "revision": "946d72266691ed1f5ad91a3ba36c59f65f1c938c",
-          "version": "0.2.31"
+          "revision": "083e1ac0e091ac0e9e7f2fa7f467ef98192da3e5",
+          "version": "0.2.33"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
         .library(name: "XCMetricsUtils", targets: ["XCMetricsUtils"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/spotify/xclogparser", from: "0.2.31"),
+        .package(url: "https://github.com/spotify/xclogparser", from: "0.2.33"),
         .package(url: "https://github.com/apple/swift-tools-support-core.git", .exact("0.2.3")),
         .package(url: "https://github.com/grpc/grpc-swift.git", .exact("1.0.0-alpha.9")),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.32.3"),


### PR DESCRIPTION
Includes a fix for parsing validate command errors: https://github.com/MobileNativeFoundation/XCLogParser/pull/157