### PR TITLE
Update xcmetrics-deployment.yaml

### DIFF
--- a/DeploymentExamples/SingleInstance/xcmetrics-deployment.yaml
+++ b/DeploymentExamples/SingleInstance/xcmetrics-deployment.yaml
@@ -51,7 +51,7 @@ spec:
         image: spotify/xcmetrics:latest
         command: ["./XCMetricsBackend",
                   "queues",
-                  "--scheduled"
+                  "--scheduled",
                   "--env",
                   "production"]
         env:


### PR DESCRIPTION
Fix typo in the config file which caused this error when run in kubectl:

```
error: error parsing xcmetrics-deployment.yaml: error converting YAML to JSON: yaml: line 54: did not find expected ',' or ']'
```