### PR TITLE
Explicitly specify required PSQL versions in documentation

### DIFF
--- a/Sources/XCMetricsBackendLib/UploadMetrics/Repository/LogFileRepositoryFactory.swift
+++ b/Sources/XCMetricsBackendLib/UploadMetrics/Repository/LogFileRepositoryFactory.swift
@@ -34,7 +34,7 @@ struct LogFileRepositoryFactory {
         if config.useS3LogRepository {
             logger.info("Initializing S3 LogFileRepository")
             guard let s3Repository = LogFileS3Repository(config: config) else {
-                preconditionFailure("AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY_ID, XCMETRICS_S3_BUCKET and " +
+                preconditionFailure("AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, XCMETRICS_S3_BUCKET and " +
                     "XCMETRICS_S3_REGION are required when XCMETRICS_USE_S3_REPOSITORY is used")
             }
             return s3Repository

--- a/docs/How to Deploy Backend.md
+++ b/docs/How to Deploy Backend.md
@@ -6,7 +6,7 @@ You can also build your own, this repo includes a Dockerfile that you can use to
 
 ## 1. Requirements
 
-The Backend needs Redis, a PostgreSQL database and optionally a Google Cloud Storage Bucket.
+The Backend needs Redis, a PostgreSQL database (>= 12) and optionally a Google Cloud Storage Bucket.
 
 You can pass the setting of those servers as Environment Variables:
 


### PR DESCRIPTION
I was deploying XCMetrics to AWS and wanted to use Aurora PostgreSQL Serverless, however the only version available is `10.14` which, I realised after the fact, is not supported by XCMetrics. The only place in the docs where PSQL's version is mentioned is in Kubernetes configs. I think it would be better if the version was explicitly stated in the `How to Deploy Backend.md` file. Though I am actually not sure if version 11 would suffice. 

Second commit, which I can push as a separate PR, just fixes a misspelling of a variable in a log message

