### PR TITLE
Build with Xcode 13.2.1 for release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,7 @@ jobs:
     name: Add macOS binaries to release
     runs-on: macOS-latest
     env:
-      XCODE_VERSION: ${{ '12.5' }}
+      XCODE_VERSION: ${{ '13.2.1' }}
     steps:
       - name: Select Xcode
         run: "sudo xcode-select -s /Applications/Xcode_$XCODE_VERSION.app"


### PR DESCRIPTION
After merging https://github.com/MobileNativeFoundation/XCLogParser/pull/177 we'll need to bump Xcode to pull in Swift 5.5+