### PR TITLE
Update Dockerfile to use Arm64 compatible Swift base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # ================================
 # Build image
 # ================================
-FROM swift:5.5-bionic as build
+FROM swift:5.6-focal as build
 WORKDIR /build
 
 # Install libraries needed
@@ -24,7 +24,7 @@ RUN swift build --enable-test-discovery --product XCMetricsBackend -c release
 # ================================
 # Run image
 # ================================
-FROM swift:5.5-bionic-slim
+FROM swift:5.6-focal-slim
 
 # Create a vapor user and group with /app as its home directory
 RUN useradd --user-group --create-home --home-dir /app vapor


### PR DESCRIPTION
Hello, 

We are using XCMetrics @ Blueground & we are transitioning to Arm64 for our production workloads. Since `swift:5.5-bionic` did not support Arm64 architecture, this was a blocker for us. 

This PR updates the base Docker image to `swift:5.6-focal` in order to be compatible with Arm64. 

Tested locally with the `docker-compose-local.yml` file! 🎉 