### PR TITLE
Add workflow action to build main branch docker images

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,34 @@
+# Run on main branch update
+# to release the latest tag on DockerHub
+name: Main branch workflow
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: spotify/xcmetrics:latest
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
Workflow that build and pushes a docker image Docker hub from the `main` branch on every push to that branch. It's configured to generate an amd64 and an arm64 docker images.

This replaces the Autobuild docker images that has been created automatically in Docker hub. If this works, I'll create a another workflow that will do the same for each release and tag.