### PR TITLE
fixed leaking password in postgres unix socket configuration

### DIFF
--- a/Sources/XCMetricsBackendLib/Config/configure.swift
+++ b/Sources/XCMetricsBackendLib/Config/configure.swift
@@ -38,7 +38,7 @@ public func configure(_ app: Application) throws {
             preconditionFailure()
         }
         let socketPath = "\(dbSocketDir)/\(cloudSQLInstanceConnectionName)/.s.PGSQL.5432"
-        app.logger.notice("Connecting to \(config.databaseName) in \(socketPath) as \(config.databaseUser.count) password length \(config.databasePassword)")
+        app.logger.notice("Connecting to \(config.databaseName) in \(socketPath) as \(config.databaseUser) password length \(config.databasePassword.count)")
         let postgresConfig = PostgresConfiguration(unixDomainSocketPath: socketPath,
                                                    username: config.databaseUser,
                                                    password: config.databasePassword,


### PR DESCRIPTION
Not sure if this was an oversight, but the postgres configuration using the unix socket is inadvertently leaking the postgres db password to the logger.
This pr fixes the leak by only logging the pw length matching the else case.