### PR TITLE
Update dependency XCLogParser to v0.2.39

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -437,8 +437,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/MobileNativeFoundation/XCLogParser",
       "state" : {
-        "revision" : "e536e3009d391513a791e08b991d6fe413be0f9c",
-        "version" : "0.2.38"
+        "revision" : "62b4d62fd4ae5e2d22bd29f7423b327149bc0ecd",
+        "version" : "0.2.39"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         .library(name: "XCMetricsUtils", targets: ["XCMetricsUtils"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/MobileNativeFoundation/XCLogParser", from: "0.2.38"),
+        .package(url: "https://github.com/MobileNativeFoundation/XCLogParser", from: "0.2.39"),
         .package(url: "https://github.com/apple/swift-tools-support-core.git", exact: "0.2.7"),
         .package(url: "https://github.com/grpc/grpc-swift.git", exact: "1.0.0-alpha.9"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.32.3"),


### PR DESCRIPTION
With Xcode 15.3 the sent metrics could no longer be processed:
```
xcmetrics-1   | [ ERROR ] [ProcessMetricsJob] error processing log from file:///tmp/0B464C1E-EE26-45B8-91B2-E10429CEA0E1/5B1E1C7B-62C2-4B1C-9C37-D82CC7359047.xcactivitylog: The line *{"utime":9,"wcStartT doesn't seem like a valid SLF line [job_id: B7B7E2AF-E4DA-4058-B137-AC4A2B6038C6]
xcmetrics-1   | [ ERROR ] Job failed with error: The line *{"utime":9,"wcStartT doesn't seem like a valid SLF line [job_id: B7B7E2AF-E4DA-4058-B137-AC4A2B6038C6, job_name: ProcessMetricsJob, queue: default]
```
To solve this problem, the version of `XCLogParser` needs to be updated to `v0.2.39`.

I've created a docker image locally to test the change. 
Please consider rebuilding the official image `spotify/xcmetrics` with this change to solve the issue #115 as well.