### PR TITLE
Update XCMetrics plugin URL to new Backstage community plugins repository  

### DIFF
--- a/docs/Backstage Integration.md
+++ b/docs/Backstage Integration.md
@@ -2,7 +2,7 @@
 
 The XCMetrics Backstage plugin offers a great way to visually analyze and inspect
 the metrics collected by XCMetrics. To use it, simply
-[install the plugin](https://github.com/backstage/backstage/tree/master/plugins/xcmetrics)
+[install the plugin](https://github.com/backstage/community-plugins/tree/main/workspaces/xcmetrics/plugins/xcmetrics)
 to your instance of Backstage and navigate to `https://<your-backstage-url>/xcmetrics`.
 
 

--- a/docs/How to Deploy Backend.md
+++ b/docs/How to Deploy Backend.md
@@ -252,7 +252,7 @@ kubectl create -f xcmetrics-jobs-deployment.yaml
 kubectl create -f xcmetrics-jobs-service.yaml
 ```
 
-If you want to use our [Web UI for Backstage](https://github.com/backstage/backstage/tree/master/plugins/xcmetrics), deploy the Scheduled Jobs:
+If you want to use our [Web UI for Backstage](https://github.com/backstage/community-plugins/tree/main/workspaces/xcmetrics/plugins/xcmetrics), deploy the Scheduled Jobs:
 ```shell
 kubectl create -f xcmetrics-scheduled-jobs-deployment.yaml
 kubectl create -f xcmetrics-scheduled-jobs-service.yaml


### PR DESCRIPTION
### **Description:**  
This PR updates the XCMetrics plugin URL from:  
🔴 **Old URL:** `https://github.com/backstage/backstage/tree/master/plugins/xcmetrics`  
🟢 **New URL:** `https://github.com/backstage/community-plugins/tree/main/workspaces/xcmetrics/plugins/xcmetrics`  

The Backstage team has migrated community plugins to a new repository (`community-plugins`), and this change ensures the link points to the correct location.  

### **Changes:**  
- Updated the XCMetrics plugin URL to the new [community-plugins](https://backstage.io/blog/2024/04/19/community-plugins/) repository.  

### **Why this change?**  
- The original link is outdated due to Backstage's repository restructuring.  
- This ensures that contributors and users can find the latest version of the XCMetrics plugin in the correct location.  

### **Testing & Validation:**  
- Verified that the new URL is accessible and correctly redirects to the XCMetrics plugin.  

### **Additional Notes:**  
- No code functionality is affected by this change—only documentation and reference updates.  