### PR TITLE
Update XCLogParser to 0.2.48 to fix parsing issues with Xcode 26.3+ logs

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -437,8 +437,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/MobileNativeFoundation/XCLogParser",
       "state" : {
-        "revision" : "e536e3009d391513a791e08b991d6fe413be0f9c",
-        "version" : "0.2.38"
+        "revision" : "0b908a0476f3ef03538455442eff39d8afe8cc10",
+        "version" : "0.2.48"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         .library(name: "XCMetricsUtils", targets: ["XCMetricsUtils"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/MobileNativeFoundation/XCLogParser", from: "0.2.38"),
+        .package(url: "https://github.com/MobileNativeFoundation/XCLogParser", from: "0.2.48"),
         .package(url: "https://github.com/apple/swift-tools-support-core.git", exact: "0.2.7"),
         .package(url: "https://github.com/grpc/grpc-swift.git", exact: "1.0.0-alpha.9"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.32.3"),


### PR DESCRIPTION
## Summary
This PR updates XCLogParser from 0.2.38 to 0.2.48.

The main goal is to fix parsing issues when processing logs generated by Xcode 26.3 or newer.

## Changes
- bump XCLogParser requirement in Package.swift to 0.2.48
- update XCLogParser pin in Package.resolved to 0.2.48

## Why
Older XCLogParser versions may fail or behave incorrectly with log formats produced by Xcode 26.3+.
Updating to 0.2.48 ensures compatibility with newer Xcode log formats.

## Testing
- not run